### PR TITLE
fix(ui): center align outline bullet dot

### DIFF
--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -393,6 +393,7 @@ hulu-text-font {
 .head-dot {
     transition: background 0.1s ease;
     border-radius: 4px;
+    align-items: center;
 }
 
 .head-dot:hover {

--- a/src/cljs/hulunote/render.cljs
+++ b/src/cljs/hulunote/render.cljs
@@ -637,7 +637,7 @@
                        :border-radius "50%"
                        :background-color "#D8D8D8"
                        :cursor "pointer"
-                       :display "inline-nav"
+                       :display "block"
                        :vertical-align "middle"}}])]))
 
 (rum/defc nav-content-editor < rum/reactive


### PR DESCRIPTION
## Summary\n- align outline row items vertically to center\n- fix invalid CSS display value on leaf bullet dot\n\n## Why\nThe bullet dot in outline rows appears visually misaligned relative to text baseline.\n\n## Changes\n- set \.head-dot to use centered cross-axis alignment\n- change leaf bullet dot display from invalid `inline-nav` to `block`\n\n## Verification\n- run desktop dev mode\n- open a note with multiple bullet rows\n- confirm leaf dots are vertically centered with text