### PR TITLE
fix(ui): improve inline editing continuity for outline blocks

### DIFF
--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -3,6 +3,11 @@
     --background-theme: #313541;
     --sidebar-width: 250px;
     --sidebar-collapsed-width: 0px;
+    --theme-accent: #4a90d9;
+    --theme-accent-glow: rgba(74, 144, 217, 0.22);
+    --bullet-idle-color: #d8d8d8;
+    --bullet-size-idle: 5px;
+    --bullet-size-editing: 8px;
 }
 
 body {
@@ -275,30 +280,38 @@ hulu-text-font {
 }
 
 .nav-editor-input {
-    border: 1px solid #4a90d9 !important;
-    border-radius: 3px !important;
-    padding: 2px 6px !important;
+    -webkit-appearance: none !important;
+    appearance: none !important;
+    border: none !important;
+    border-radius: 0 !important;
+    padding: 0 !important;
+    padding-left: 0.5px !important;
     outline: none !important;
-    width: calc(100% - 50px) !important;
-    min-width: 200px !important;
-    font-size: inherit !important;
-    font-family: inherit !important;
-    background: #2a2f3a !important;
-    color: #fdfeffc4 !important;
+    width: 100% !important;
+    min-width: 100px !important;
+    font: inherit !important;
+    font-weight: inherit !important;
+    letter-spacing: inherit !important;
+    line-height: inherit !important;
+    text-indent: 0 !important;
+    background: transparent !important;
+    color: inherit !important;
+    box-shadow: none !important;
+    margin: 0 !important;
 }
 
 .nav-editor-input:focus {
-    border-color: #2e7ad1 !important;
-    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2) !important;
-    background: #2a2f3a !important;
-    color: #fdfeffc4 !important;
+    border: none !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    color: inherit !important;
 }
 
 .night-textColor-2 .nav-editor-input,
 .night-center-boxBg .nav-editor-input {
-    background: #2a2f3a !important;
-    color: #fdfeffc4 !important;
-    border-color: #4a90d9 !important;
+    background: transparent !important;
+    color: inherit !important;
+    border: none !important;
 }
 
 .outline-line:hover {
@@ -393,10 +406,15 @@ hulu-text-font {
 .head-dot {
     transition: background 0.1s ease;
     border-radius: 4px;
+    align-items: center;
 }
 
 .head-dot:hover {
     background: rgba(255, 255, 255, 0.03);
+}
+
+.head-dot.is-editing {
+    background: rgba(255, 255, 255, 0.05);
 }
 
 /* ==================== Daily Note Button ==================== */

--- a/src/cljs/hulunote/render.cljs
+++ b/src/cljs/hulunote/render.cljs
@@ -601,7 +601,7 @@
 
 (rum/defc nav-bullet < rum/reactive
   "Bullet point component with expand/collapse functionality and context menu"
-  [db nav-id is-display note-id database-name content]
+  [db nav-id is-display note-id database-name content is-editing]
   (let [has-child (has-children? db nav-id)]
     [:span {:class (str "controls hulu-text-font " 
                         (when has-child "has-children"))
@@ -632,12 +632,13 @@
         "▶"]
        ;; Show dot for leaf nodes
        [:span {:class "controls bg-black-50 customize-dot night-circular"
-               :style {:height 5
-                       :width 5
+               :style {:height (if is-editing "var(--bullet-size-editing)" "var(--bullet-size-idle)")
+                       :width (if is-editing "var(--bullet-size-editing)" "var(--bullet-size-idle)")
                        :border-radius "50%"
-                       :background-color "#D8D8D8"
+                       :background-color (if is-editing "var(--theme-accent)" "var(--bullet-idle-color)")
+                       :box-shadow (when is-editing "0 0 0 2px var(--theme-accent-glow)")
                        :cursor "pointer"
-                       :display "inline-nav"
+                       :display "block"
                        :vertical-align "middle"}}])]))
 
 (rum/defc nav-content-editor < rum/reactive
@@ -649,17 +650,19 @@
        {:type "text"
         :auto-focus true
         :value (rum/react editing-content)
-        :style {:border "1px solid #4a90d9"
-                :border-radius "3px"
-                :padding "2px 6px"
+        :style {:border "none"
+                :border-radius "0"
+                :padding "0"
                 :outline "none"
                 :width "100%"
-                :min-width "200px"
+                :min-width "100px"
                 :font-size "inherit"
                 :font-family "inherit"
-                ;; Fixed: Use dark background with light text for dark theme
-                :background "#2a2f3a"
-                :color "#fdfeffc4"}
+                :font-weight "inherit"
+                :letter-spacing "inherit"
+                :line-height "inherit"
+                :background "transparent"
+                :color "inherit"}
         :on-change #(reset! editing-content (.. % -target -value))
         :on-key-down #(handle-key-down % nav-id note-id database-name)
         :on-blur #(save-nav-content! nav-id note-id database-name)}]
@@ -682,17 +685,17 @@
         is-editing (= id (rum/react editing-nav-id))]
     [:div.nav-item
      ;; Entire row is clickable to enter edit mode
-     [:div.head-dot.flex
-      {:style {:padding-left "13px"
-               :padding-top "5px"
-               :padding-bottom "5px"
-               :cursor "text"}
-       :on-click (fn [e]
-                   ;; Only start editing if not clicking on bullet
-                   (when-not (.. e -target -classList (contains "controls"))
-                     (reset! target-cursor-column nil)
-                     (start-editing! id content)))}
-      (nav-bullet db id is-display note-id database-name content)
+     [:div {:class (str "head-dot flex " (when is-editing "is-editing"))
+            :style {:padding-left "13px"
+                    :padding-top "5px"
+                    :padding-bottom "5px"
+                    :cursor "text"}
+            :on-click (fn [e]
+                        ;; Only start editing if not clicking on bullet
+                        (when-not (.. e -target -classList (contains "controls"))
+                          (reset! target-cursor-column nil)
+                          (start-editing! id content)))}
+      (nav-bullet db id is-display note-id database-name content is-editing)
       (nav-content-editor id content note-id database-name)]
      (when is-display
        [:div.content-box {:style {:margin-left "24px"


### PR DESCRIPTION
## Summary
- make block editing feel in-place instead of a separate input box
- reduce text position shift between view and edit states
- highlight editing leaf bullet with larger size, accent color, and subtle glow
- replace hardcoded bullet/accent values with theme CSS variables

## Why
Current edit mode introduces a strong visual split (boxed input style) and slight text shift, which feels less natural than Roam-style inline editing.

## Changes
- input style aligned to display typography and spacing (transparent, no box border/focus ring)
- editing row uses subtle state highlight
- editing leaf bullet state:
  - size: idle -> editing
  - color: idle -> accent
  - subtle glow during editing
- added theme variables in CSS root:
  - --theme-accent
  - --theme-accent-glow
  - --bullet-idle-color
  - --bullet-size-idle
  - --bullet-size-editing

## Verification
- run desktop dev mode (shadow-cljs watch + electron start:dev)
- click multiple nodes to enter edit mode
- confirm:
  - no obvious boxed input transition
  - minimal text position shift
  - active leaf bullet becomes larger + accent + subtle glow
  - inactive bullets remain unchanged
