### PR TITLE
refactor(ui): align diaries title behavior and accent styles with design tokens

### DIFF
--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -3,12 +3,33 @@
     --background-theme: #313541;
     --sidebar-width: 250px;
     --sidebar-collapsed-width: 0px;
-    --theme-accent: #4a90d9;
-    --theme-accent-glow: rgba(74, 144, 217, 0.22);
+    /* UI design system tokens */
+    --color-primary: #667eea;
+    --color-primary-glow: rgba(102, 126, 234, 0.3);
+    --text-primary: #1a1a2e;
+    --text-secondary: #666666;
+    --text-muted: #999999;
+    --border-color: #e0e0e0;
+    --space-xs: 8px;
+    --space-sm: 12px;
+    --space-md: 16px;
+    --space-lg: 24px;
+    --space-xl: 32px;
+    --space-2xl: 40px;
+    --space-3xl: 48px;
+    --space-4xl: 80px;
+    --theme-accent: var(--color-primary);
+    --theme-accent-glow: var(--color-primary-glow);
+    --theme-accent-15: rgba(102, 126, 234, 0.15);
+    --theme-accent-20: rgba(102, 126, 234, 0.2);
+    --theme-accent-30: rgba(102, 126, 234, 0.3);
+    --theme-accent-hover: #6f88f0;
+    --theme-accent-strong: #5570e2;
     --bullet-idle-color: #d8d8d8;
     --bullet-collapsed-glow: rgba(216, 216, 216, 0.28);
     --bullet-size-idle: 5px;
     --bullet-size-editing: 8px;
+    --note-title-align-left: calc(var(--space-xl) + 4px);
 }
 
 body {
@@ -43,7 +64,7 @@ body {
     border-bottom-color: rgb(191, 204, 214);
     border-left-color: rgb(191, 204, 214);
     position: absolute;
-    left: 9px;
+    left: calc(var(--space-xs) + 1px);
 }
 
 div.content-box.outline-line:hover {
@@ -289,7 +310,7 @@ hulu-text-font {
     border: none !important;
     border-radius: 0 !important;
     padding: 0 !important;
-    padding-left: 1px !important;
+    padding-left: calc(var(--space-xs) / 8) !important;
     outline: none !important;
     width: 100% !important;
     min-width: 100px !important;
@@ -319,7 +340,7 @@ hulu-text-font {
 }
 
 .outline-line:hover {
-    border-right: 2px solid #4a90d9 !important;
+    border-right: 2px solid var(--theme-accent) !important;
 }
 
 .content-box {
@@ -532,8 +553,8 @@ hulu-text-font {
 }
 
 .sidebar-item.active {
-    background: rgba(74, 144, 217, 0.2);
-    border-left: 3px solid #4a90d9;
+    background: var(--theme-accent-20);
+    border-left: 3px solid var(--theme-accent);
 }
 
 .sidebar-item-icon {
@@ -555,7 +576,7 @@ hulu-text-font {
 .new-note-btn {
     margin: 12px 16px;
     padding: 10px 16px;
-    background: #4a90d9;
+    background: var(--theme-accent);
     color: #fff;
     border: none;
     border-radius: 6px;
@@ -570,7 +591,7 @@ hulu-text-font {
 }
 
 .new-note-btn:hover {
-    background: #3d7ec7;
+    background: var(--theme-accent-strong);
 }
 
 .new-note-btn-icon {
@@ -602,7 +623,7 @@ hulu-text-font {
 }
 
 .note-list-item.active {
-    background: rgba(74, 144, 217, 0.15);
+    background: var(--theme-accent-15);
     opacity: 1;
 }
 
@@ -635,7 +656,7 @@ hulu-text-font {
 .note-title-wrapper {
     display: flex;
     align-items: center;
-    padding: 8px 0;
+    padding: 8px 0 8px var(--note-title-align-left);
     margin-bottom: 8px;
 }
 
@@ -643,13 +664,13 @@ hulu-text-font {
     font-size: 1.5rem;
     font-weight: bold;
     cursor: pointer;
-    padding: 4px 8px;
+    padding: 4px 0;
     border-radius: 4px;
     transition: background 0.2s ease;
 }
 
 .note-title:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: transparent;
 }
 
 .note-title-input {
@@ -657,17 +678,17 @@ hulu-text-font {
     font-weight: bold;
     background: #2a2f3a !important;
     color: #fdfeffc4 !important;
-    border: 1px solid #4a90d9 !important;
+    border: 1px solid var(--theme-accent) !important;
     border-radius: 4px;
-    padding: 4px 8px;
+    padding: 4px 0;
     outline: none;
     width: 100%;
     max-width: 600px;
 }
 
 .note-title-input:focus {
-    border-color: #2e7ad1 !important;
-    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
+    border-color: var(--theme-accent) !important;
+    box-shadow: 0 0 0 2px var(--theme-accent-glow);
 }
 
 /* ==================== All Notes Page ==================== */
@@ -684,7 +705,7 @@ hulu-text-font {
 
 .note-card:hover {
     background: rgba(255,255,255,0.1);
-    border-color: rgba(74, 144, 217, 0.3);
+    border-color: var(--theme-accent-30);
     transform: translateY(-1px);
 }
 
@@ -710,7 +731,7 @@ hulu-text-font {
 
 .pagination-btn {
     padding: 8px 16px;
-    background: #4a90d9;
+    background: var(--theme-accent);
     color: #fff;
     border: none;
     border-radius: 4px;
@@ -719,7 +740,7 @@ hulu-text-font {
 }
 
 .pagination-btn:hover:not(:disabled) {
-    background: #3d7ec7;
+    background: var(--theme-accent-strong);
 }
 
 .pagination-btn:disabled {
@@ -743,8 +764,8 @@ hulu-text-font {
 }
 
 .pagination-num.active {
-    background: #4a90d9;
-    border-color: #4a90d9;
+    background: var(--theme-accent);
+    border-color: var(--theme-accent);
 }
 
 /* ==================== Mobile Responsive ==================== */
@@ -803,7 +824,7 @@ hulu-text-font {
 }
 
 .link-title-style {
-    color: #4a90d9 !important;
+    color: var(--theme-accent) !important;
     text-decoration: underline;
     text-decoration-style: dotted;
     text-underline-offset: 2px;
@@ -811,7 +832,7 @@ hulu-text-font {
 }
 
 .link-title-style:hover {
-    color: #6ab0ff !important;
+    color: var(--theme-accent-hover) !important;
     text-decoration-style: solid;
 }
 
@@ -822,7 +843,7 @@ hulu-text-font {
 
 /* Page link hover effect - highlight the brackets */
 .hulunote-note-link:hover .link-style.blue {
-    color: #4a90d9 !important;
+    color: var(--theme-accent) !important;
 }
 
 /* Hashtag specific styles */

--- a/src/cljs/hulunote/all_notes.cljs
+++ b/src/cljs/hulunote/all_notes.cljs
@@ -180,7 +180,7 @@
         {:disabled (= page 1)
          :on-click #(go-to-page! (dec page))
          :style {:padding "8px 16px"
-                 :background (if (= page 1) "#3d4455" "#4a90d9")
+                 :background (if (= page 1) "#3d4455" "var(--theme-accent)")
                  :color "#fff"
                  :border "none"
                  :border-radius "4px"
@@ -195,7 +195,7 @@
            {:key p
             :on-click #(go-to-page! p)
             :style {:padding "8px 12px"
-                    :background (if (= p page) "#4a90d9" "transparent")
+                    :background (if (= p page) "var(--theme-accent)" "transparent")
                     :color "#fff"
                     :border (if (= p page) "none" "1px solid rgba(255,255,255,0.2)")
                     :border-radius "4px"
@@ -207,7 +207,7 @@
         {:disabled (= page pages)
          :on-click #(go-to-page! (inc page))
          :style {:padding "8px 16px"
-                 :background (if (= page pages) "#3d4455" "#4a90d9")
+                 :background (if (= page pages) "#3d4455" "var(--theme-accent)")
                  :color "#fff"
                  :border "none"
                  :border-radius "4px"

--- a/src/cljs/hulunote/components.cljs
+++ b/src/cljs/hulunote/components.cljs
@@ -196,7 +196,7 @@
                   (navigate-to-note-by-title! title-str))}
      [:span.link-style.blue "[["]
      [:span.link-title-style
-      {:style {:color "#4a90d9"
+      {:style {:color "var(--theme-accent)"
                :text-decoration "underline"
                :text-decoration-style "dotted"}}
       title-str]
@@ -215,7 +215,7 @@
                   (navigate-to-note-by-title! title-str))}
      [:span.link-style.blue "#"]
      [:span.link-title-style
-      {:style {:color "#4a90d9"
+      {:style {:color "var(--theme-accent)"
                :text-decoration "underline"
                :text-decoration-style "dotted"}}
       title-str]]))

--- a/src/cljs/hulunote/diaries.cljs
+++ b/src/cljs/hulunote/diaries.cljs
@@ -65,20 +65,12 @@
       (cancel-editing-title!))))
 
 (rum/defc note-title-editor < rum/reactive
-  "Editable note title component"
+  "Read-only note title component for diaries list"
   [note-id note-title database-name]
-  (let [is-editing (= note-id (rum/react editing-note-id))]
-    (if is-editing
-      [:input.note-title-input
-       {:type "text"
-        :auto-focus true
-        :value (rum/react editing-note-title)
-        :on-change #(reset! editing-note-title (.. % -target -value))
-        :on-key-down #(handle-title-key-down % note-id database-name)
-        :on-blur #(save-note-title! note-id database-name)}]
-      [:div.note-title
-       {:on-click #(start-editing-title! note-id note-title)}
-       note-title])))
+  [:div.note-title
+   {:style {:cursor "pointer"}
+    :on-click #(router/go-to-note! database-name note-id)}
+   note-title])
 
 ;; Lifecycle mixin to initialize daily note when component mounts
 (def daily-note-init-mixin
@@ -164,7 +156,7 @@
                (render/render-navs db root-nav-id note-id database-name)]
               
               ;; Separator
-              [:div {:style {:padding "35px 0"}}
+              [:div {:style {:padding "calc(var(--space-4xl) + var(--space-lg)) 0 calc(var(--space-xl) + 3px) 0"}}
                [:div {:style {:background "rgba(151, 151, 151, 0.25)"
                               :height "1px" :width "100%"}}]]])))
        

--- a/src/cljs/hulunote/render.cljs
+++ b/src/cljs/hulunote/render.cljs
@@ -661,8 +661,8 @@
       (when has-child
         [:span
          {:class (str "controls expand-icon " (if is-display "expanded" "collapsed"))
-          :style {:font-size "9px"
-                  :color "#7f8898"
+         :style {:font-size "9px"
+                  :color "var(--text-muted)"
                   :transition "transform 0.15s ease, color 0.15s ease"
                   :transform (if is-display "rotate(90deg)" "rotate(0deg)")
                   :display "inline-block"

--- a/src/cljs/hulunote/single_note.cljs
+++ b/src/cljs/hulunote/single_note.cljs
@@ -291,7 +291,7 @@
            (str "Note ID: " note-id)]
           [:button
            {:on-click #(router/go-to-diaries! database)
-            :style {:background "#4a90d9"
+            :style {:background "var(--theme-accent)"
                     :border "none"
                     :color "#fff"
                     :padding "10px 20px"


### PR DESCRIPTION
## Summary\n- make diaries note titles read-only in list and navigate to note on click\n- remove diaries title hover background for non-editable title\n- align diaries separator spacing with token-based values\n- replace remaining hard-coded accent colors in related UI with theme token vars\n\n## Manual checks\n- in Diaries list, title is no longer editable inline\n- clicking diary title opens the note page\n- separator spacing remains visually consistent with previous tuned layout\n- pagination / links / sidebar accent colors still match current visual style