### PR TITLE
feat(ui): 全局顶栏布局重构与侧边栏图标统一

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -44,6 +44,9 @@ function createWindow() {
     },
     icon: path.join(__dirname, 'icons', 'icon.png'),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    ...(process.platform === 'darwin'
+      ? { trafficLightPosition: { x: 14, y: 18 } }
+      : {}),
     show: false,
     backgroundColor: '#ffffff'
   });

--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -30,6 +30,7 @@
     --bullet-size-idle: 5px;
     --bullet-size-editing: 8px;
     --note-title-align-left: calc(var(--space-xl) + 4px);
+    --app-topbar-height: 56px;
 }
 
 body {
@@ -463,8 +464,9 @@ hulu-text-font {
 
 .page-wrapper {
     display: flex;
-    min-height: 100vh;
+    min-height: calc(100vh - var(--app-topbar-height));
     position: relative;
+    padding-top: var(--app-topbar-height);
 }
 
 /* ==================== Sidebar Styles ==================== */
@@ -472,8 +474,8 @@ hulu-text-font {
 .left-sidebar {
     position: fixed;
     left: 0;
-    top: 0;
-    height: 100vh;
+    top: var(--app-topbar-height);
+    height: calc(100vh - var(--app-topbar-height));
     width: var(--sidebar-width);
     background: #2e3340;
     border-right: 1px solid rgba(255, 255, 255, 0.1);
@@ -482,7 +484,7 @@ hulu-text-font {
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    padding-top: 28px; /* macOS traffic light buttons spacing */
+    padding-top: 0;
 }
 
 .left-sidebar.collapsed {
@@ -492,7 +494,7 @@ hulu-text-font {
 .sidebar-toggle-btn {
     position: fixed;
     left: var(--sidebar-width);
-    top: 36px; /* 28px macOS spacing + 8px */
+    top: calc(var(--app-topbar-height) + 8px);
     width: 32px;
     height: 32px;
     background: #3d4455;
@@ -554,7 +556,7 @@ hulu-text-font {
 
 .sidebar-item.active {
     background: var(--theme-accent-20);
-    border-left: 3px solid var(--theme-accent);
+    box-shadow: inset 3px 0 0 var(--theme-accent);
 }
 
 .sidebar-item-icon {
@@ -564,6 +566,12 @@ hulu-text-font {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.sidebar-symbol-icon {
+    font-size: 18px !important;
+    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 20;
+    line-height: 1;
 }
 
 .sidebar-item-text {
@@ -642,13 +650,99 @@ hulu-text-font {
     flex: 1;
     margin-left: var(--sidebar-width);
     transition: margin-left 0.3s ease;
-    min-height: 100vh;
+    min-height: calc(100vh - var(--app-topbar-height));
     overflow-y: auto;
-    padding-top: 28px; /* macOS traffic light buttons spacing */
+    padding-top: 0;
 }
 
 .main-content-area.sidebar-collapsed {
     margin-left: 0;
+}
+
+/* ==================== App Top Bar ==================== */
+
+.app-topbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 90;
+    height: var(--app-topbar-height);
+    padding: 0 16px 0 16px;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    background: rgba(46, 51, 64, 0.94);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(8px);
+}
+
+.app-topbar-left,
+.app-topbar-right {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.app-topbar-left {
+    padding-left: 74px; /* avoid overlap with macOS traffic-light controls */
+}
+
+.app-topbar-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+}
+
+.app-topbar-tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    max-width: 100%;
+    height: 30px;
+    padding: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+    background: transparent;
+    border: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.app-topbar-tab.active {
+    background: transparent;
+    border: none;
+}
+
+.app-topbar-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.82);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    line-height: 1;
+    padding: 0;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.app-topbar-icon {
+    font-size: 18px !important;
+}
+
+.app-topbar-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: #fff;
 }
 
 /* ==================== Note Title Editor ==================== */
@@ -771,13 +865,17 @@ hulu-text-font {
 /* ==================== Mobile Responsive ==================== */
 
 @media only screen and (max-width: 768px) {
+    :root {
+        --app-topbar-height: 44px;
+    }
+
     .left-sidebar {
         width: 100%;
     }
     
     .sidebar-toggle-btn {
         left: 0;
-        top: 16px;
+        top: calc(var(--app-topbar-height) + 8px);
         border-radius: 0 6px 6px 0;
     }
     
@@ -787,6 +885,21 @@ hulu-text-font {
     
     .main-content-area {
         margin-left: 0;
+    }
+
+    .app-topbar {
+        height: var(--app-topbar-height);
+        padding: 0 8px;
+        gap: 8px;
+    }
+
+    .app-topbar-left {
+        padding-left: 0;
+    }
+
+    .app-topbar-tab {
+        font-size: 12px;
+        height: 28px;
     }
     
     .left-sidebar:not(.collapsed) ~ .main-content-area {

--- a/resources/public/html/hulunote.html
+++ b/resources/public/html/hulunote.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link rel="stylesheet" href="/css/tachyons.min.css"/>
     <link rel="stylesheet" href="/css/animate.min.css"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20,400,0,0"/>
     <link rel="stylesheet" href="/css/hulunote.css"/>
   </head>
   <body>

--- a/src/cljs/hulunote/all_notes.cljs
+++ b/src/cljs/hulunote/all_notes.cljs
@@ -263,63 +263,50 @@
         page (rum/react current-page)
         paginated-notes (get-paginated-notes all-notes page)
         sidebar-collapsed? (rum/react sidebar/sidebar-collapsed?)]
-    [:div.page-wrapper.night-center-boxBg.night-textColor-2
-     
-     ;; Left sidebar
-     (sidebar/left-sidebar db database-name)
-     
-     ;; Main content area
-     [:div.main-content-area
-      {:class (when sidebar-collapsed? "sidebar-collapsed")}
-      ;; Back button
-      [:div {:style {:padding "8px 16px"}}
-       [:button
-        {:on-click #(js/history.back)
-         :style {:background "transparent"
-                 :border "1px solid rgba(255,255,255,0.2)"
-                 :color "#fff"
-                 :padding "6px 12px"
-                 :border-radius "4px"
-                 :cursor "pointer"
-                 :font-size "13px"}}
-        "← Back"]]
-      [:div.flex.flex-column
-       {:style {:padding "20px"
-                :max-width "900px"
-                :margin "0 auto"}}
-       
-       ;; Page header
-       [:div {:style {:margin-bottom "24px"}}
-        [:h1 {:style {:font-size "24px" 
-                      :font-weight "600"
-                      :margin "0 0 8px 0"}}
-         "All Notes"]
-        [:div {:style {:color "rgba(255,255,255,0.6)"
-                       :font-size "14px"}}
-         (str "Total: " (count all-notes) " notes")]]
-       
-       ;; Notes list
-       (if (empty? all-notes)
-         [:div.flex.flex-column.items-center.justify-center
-          {:style {:height "50vh"}}
-          [:div {:style {:font-size "18px" :margin-bottom "16px"}} 
-           "No notes yet"]
-          [:button.new-note-btn
-           {:on-click #(sidebar/create-new-note! database-name)}
-           [:span.new-note-btn-icon "+"]
-           "Create First Note"]]
-         
-         [:div
-          ;; Note cards
-          (for [[note-id note-title root-nav-id updated-at] paginated-notes]
-            (rum/with-key
-              (note-card note-id note-title updated-at database-name)
-              note-id))
-          
-          ;; Pagination
-          (pagination-controls (count all-notes))])
-       
-       [:div {:style {:height "50px"}}]]]
-     
-     ;; Global note menu
-     (note-menu)]))
+    [:div.night-center-boxBg.night-textColor-2
+     (sidebar/app-top-bar {:title "All Notes"})
+     [:div.page-wrapper
+      ;; Left sidebar
+      (sidebar/left-sidebar db database-name)
+      ;; Main content area
+      [:div.main-content-area
+       {:class (when sidebar-collapsed? "sidebar-collapsed")}
+       [:div.flex.flex-column
+        {:style {:padding "20px"
+                 :max-width "900px"
+                 :margin "0 auto"}}
+
+        ;; Page header
+        [:div {:style {:margin-bottom "24px"}}
+         [:h1 {:style {:font-size "24px"
+                       :font-weight "600"
+                       :margin "0 0 8px 0"}}
+          "All Notes"]
+         [:div {:style {:color "rgba(255,255,255,0.6)"
+                        :font-size "14px"}}
+          (str "Total: " (count all-notes) " notes")]]
+
+        ;; Notes list
+        (if (empty? all-notes)
+          [:div.flex.flex-column.items-center.justify-center
+           {:style {:height "50vh"}}
+           [:div {:style {:font-size "18px" :margin-bottom "16px"}}
+            "No notes yet"]
+           [:button.new-note-btn
+            {:on-click #(sidebar/create-new-note! database-name)}
+            [:span.new-note-btn-icon "+"]
+            "Create First Note"]]
+
+          [:div
+           ;; Note cards
+           (for [[note-id note-title root-nav-id updated-at] paginated-notes]
+             (rum/with-key
+               (note-card note-id note-title updated-at database-name)
+               note-id))
+
+           ;; Pagination
+           (pagination-controls (count all-notes))])
+
+        [:div {:style {:height "50px"}}]]]
+      ;; Global note menu
+      (note-menu)]]))

--- a/src/cljs/hulunote/diaries.cljs
+++ b/src/cljs/hulunote/diaries.cljs
@@ -92,72 +92,60 @@
   (let [daily-list (db/sort-daily-list (db/get-daily-list db))
         database-name (get-current-database-name db)
         sidebar-collapsed? (rum/react sidebar/sidebar-collapsed?)]
-    [:div.page-wrapper.night-center-boxBg.night-textColor-2
-     
-     ;; Left sidebar
-     (sidebar/left-sidebar db database-name)
-     
-     ;; Main content area
-     [:div.main-content-area
-      {:class (when sidebar-collapsed? "sidebar-collapsed")}
-      ;; Back button
-      [:div {:style {:padding "8px 16px"}}
-       [:button
-        {:on-click #(js/history.back)
-         :style {:background "transparent"
-                 :border "1px solid rgba(255,255,255,0.2)"
-                 :color "#fff"
-                 :padding "6px 12px"
-                 :border-radius "4px"
-                 :cursor "pointer"
-                 :font-size "13px"}}
-        "← Back"]]
-      [:div.flex.flex-column.overflow-scroll-new
-       {:style {:padding "20px"
-                :max-width "900px"
-                :margin "0 auto"}}
-       
-       (if (empty? daily-list)
-         ;; Empty state - show message and create first note button
-         [:div.flex.flex-column.items-center.justify-center
-          {:style {:height "80vh"}}
-          [:div {:style {:font-size "24px" :margin-bottom "20px"}} 
-           "No notes yet"]
-          [:div {:style {:color "rgba(255,255,255,0.6)" :margin-bottom "30px"}}
-           "Create your first note to get started"]
-          [:button.new-note-btn
-           {:on-click #(sidebar/create-new-note! database-name)}
-           [:span.new-note-btn-icon "+"]
-           "Create First Note"]
-          ;; Add quick create today's note button
-          [:button
-           {:style {:margin-top "16px"
-                    :background "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
-                    :color "#fff"
-                    :border "none"
-                    :border-radius "8px"
-                    :padding "12px 24px"
-                    :font-size "14px"
-                    :cursor "pointer"}
-            :on-click #(sidebar/ensure-daily-note! database-name {:navigate? true})}
-           (str "📅 Create Today's Note (" (sidebar/get-today-title) ")")]]
-         
-         ;; Show existing notes
-         (for [item daily-list]
-           (let [[note-title note-id root-nav-id] item]
-             [:div {:key note-id
-                    :style {:margin-bottom "40px"}}
-              ;; Editable note title
-              [:div.note-title-wrapper
-               (note-title-editor note-id note-title database-name)]
-              
-              ;; Nav outline
-              [:div {:style {:padding-left "12px"}}
-               (render/render-navs db root-nav-id note-id database-name)]
-              
-              ;; Separator
-              [:div {:style {:padding "calc(var(--space-4xl) + var(--space-lg)) 0 calc(var(--space-xl) + 3px) 0"}}
-               [:div {:style {:background "rgba(151, 151, 151, 0.25)"
-                              :height "1px" :width "100%"}}]]])))
-       
-       [:div {:style {:height "100px"}}]]]]))
+    [:div.night-center-boxBg.night-textColor-2
+     (sidebar/app-top-bar {:title "Diaries"})
+     [:div.page-wrapper
+      ;; Left sidebar
+      (sidebar/left-sidebar db database-name)
+      ;; Main content area
+      [:div.main-content-area
+       {:class (when sidebar-collapsed? "sidebar-collapsed")}
+       [:div.flex.flex-column.overflow-scroll-new
+        {:style {:padding "20px"
+                 :max-width "900px"
+                 :margin "0 auto"}}
+
+        (if (empty? daily-list)
+          ;; Empty state - show message and create first note button
+          [:div.flex.flex-column.items-center.justify-center
+           {:style {:height "80vh"}}
+           [:div {:style {:font-size "24px" :margin-bottom "20px"}}
+            "No notes yet"]
+           [:div {:style {:color "rgba(255,255,255,0.6)" :margin-bottom "30px"}}
+            "Create your first note to get started"]
+           [:button.new-note-btn
+            {:on-click #(sidebar/create-new-note! database-name)}
+            [:span.new-note-btn-icon "+"]
+            "Create First Note"]
+           ;; Add quick create today's note button
+           [:button
+            {:style {:margin-top "16px"
+                     :background "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+                     :color "#fff"
+                     :border "none"
+                     :border-radius "8px"
+                     :padding "12px 24px"
+                     :font-size "14px"
+                     :cursor "pointer"}
+             :on-click #(sidebar/ensure-daily-note! database-name {:navigate? true})}
+            (str "📅 Create Today's Note (" (sidebar/get-today-title) ")")]]
+
+          ;; Show existing notes
+          (for [item daily-list]
+            (let [[note-title note-id root-nav-id] item]
+              [:div {:key note-id
+                     :style {:margin-bottom "40px"}}
+               ;; Editable note title
+               [:div.note-title-wrapper
+                (note-title-editor note-id note-title database-name)]
+
+               ;; Nav outline
+               [:div {:style {:padding-left "12px"}}
+                (render/render-navs db root-nav-id note-id database-name)]
+
+               ;; Separator
+               [:div {:style {:padding "calc(var(--space-4xl) + var(--space-lg)) 0 calc(var(--space-xl) + 3px) 0"}}
+                [:div {:style {:background "rgba(151, 151, 151, 0.25)"
+                               :height "1px" :width "100%"}}]]])))
+
+        [:div {:style {:height "100px"}}]]]]]))

--- a/src/cljs/hulunote/render.cljs
+++ b/src/cljs/hulunote/render.cljs
@@ -769,7 +769,9 @@
                                (when-let [db-id (:database-id nav-info)]
                                  ;; Try to get database name from database-id
                                  db-id))]
-        (nav-input db id actual-note-id actual-db-name)))))
+        (rum/with-key
+          (nav-input db id actual-note-id actual-db-name)
+          (or id dbid))))))
 
 ;; Global context menu - render at app level
 (rum/defc global-context-menu < rum/reactive

--- a/src/cljs/hulunote/sidebar.cljs
+++ b/src/cljs/hulunote/sidebar.cljs
@@ -225,6 +225,41 @@
    [:div.sidebar-item-icon icon]
    [:div.sidebar-item-text text]])
 
+(rum/defc app-top-bar
+  "Global top bar for app pages.
+   The bar itself is draggable in Electron, while controls remain clickable."
+  [{:keys [title]}]
+  [:div.app-topbar
+   {:style {:-webkit-app-region "drag"}}
+   [:div.app-topbar-left
+    {:style {:-webkit-app-region "no-drag"}}
+    [:button.app-topbar-btn
+     {:title "Dock To Right (placeholder)"
+      :on-click toggle-sidebar!}
+     [:span.material-symbols-outlined.app-topbar-icon "dock_to_right"]]
+    [:button.app-topbar-btn
+     {:title "Back"
+      :on-click #(js/history.back)}
+     [:span.material-symbols-outlined.app-topbar-icon "arrow_back"]]
+    [:button.app-topbar-btn
+     {:title "Forward"
+      :on-click #(js/history.forward)}
+     [:span.material-symbols-outlined.app-topbar-icon "arrow_forward"]]]
+   [:div.app-topbar-center
+    {:style {:-webkit-app-region "no-drag"}}
+    [:div.app-topbar-tab.active
+     (or title "Untitled")]]
+   [:div.app-topbar-right
+    {:style {:-webkit-app-region "no-drag"}}
+   [:button.app-topbar-btn
+     {:title "Search (placeholder)"
+      :on-click #()}
+     [:span.material-symbols-outlined.app-topbar-icon "search"]]
+    [:button.app-topbar-btn
+     {:title "Dock To Left (placeholder)"
+      :on-click #()}
+     [:span.material-symbols-outlined.app-topbar-icon "dock_to_left"]]]])
+
 (rum/defc left-sidebar < rum/reactive
   [db database-name]
   (let [collapsed? (rum/react sidebar-collapsed?)
@@ -234,7 +269,7 @@
      ;; Sidebar container
      [:div.left-sidebar
       {:class (when collapsed? "collapsed")}
-      
+
       (when-not collapsed?
         [:<>
          ;; Sidebar header with logo
@@ -244,12 +279,6 @@
                   :width "24px"
                   :style {:border-radius "50%"}}]
            [:span.sidebar-title.ml2 "HULUNOTE"]]]
-         
-         ;; New note button
-         [:button.new-note-btn
-          {:on-click #(create-new-note! database-name)}
-          [:span.new-note-btn-icon "+"]
-          "New Note"]
          
          ;; Today's Daily Note button
          [:button.daily-note-btn
@@ -274,19 +303,19 @@
          ;; Sidebar content
          [:div.sidebar-content
           ;; Menu items
-          (sidebar-item "📅" "Diaries" 
+          (sidebar-item [:span.material-symbols-outlined.sidebar-symbol-icon "calendar_month"] "Diaries"
                         #(router/go-to-diaries! database-name)
                         (= route-name :diaries))
-          
-          (sidebar-item "📝" "All Notes"
+
+          (sidebar-item [:span.material-symbols-outlined.sidebar-symbol-icon "description"] "All Notes"
                         #(router/go-to-all-notes! database-name)
                         (= route-name :all-notes))
 
-          (sidebar-item "🔌" "MCP Settings"
+          (sidebar-item [:span.material-symbols-outlined.sidebar-symbol-icon "tune"] "MCP Settings"
                         #(router/go-to-mcp-settings! database-name)
                         (= route-name :mcp-settings))
 
-          (sidebar-item "💬" "MCP Chat"
+          (sidebar-item [:span.material-symbols-outlined.sidebar-symbol-icon "chat_bubble"] "MCP Chat"
                         #(router/go-to-mcp-chat! database-name)
                         (= route-name :mcp-chat))
 
@@ -299,11 +328,16 @@
               {:key note-id
                :on-click #(router/go-to-note! database-name note-id)
                :title note-title}
-              note-title])]]])]
-     
-     ;; Toggle button - always visible, positioned at edge of sidebar
-     [:div.sidebar-toggle-btn
-      {:class (when collapsed? "collapsed")
-       :on-click toggle-sidebar!
-       :title (if collapsed? "展开侧边栏" "收起侧边栏")}
-      (if collapsed? "☰" "✕")]]))
+              note-title])]]
+
+         ;; Bottom fixed action
+         [:div
+          {:style {:padding "12px 16px"
+                   :border-top "1px solid rgba(255, 255, 255, 0.08)"
+                   :flex-shrink 0}}
+          [:button.new-note-btn
+           {:style {:margin "0"
+                    :width "100%"}
+            :on-click #(create-new-note! database-name)}
+           [:span.new-note-btn-icon "+"]
+           "New Note"]]])]]))

--- a/src/cljs/hulunote/single_note.cljs
+++ b/src/cljs/hulunote/single_note.cljs
@@ -244,65 +244,51 @@
   (let [{:keys [database note-id]} (get-route-params db)
         note-info (when note-id (get-note-by-id db note-id))
         sidebar-collapsed? (rum/react sidebar/sidebar-collapsed?)]
-    [:div.page-wrapper.night-center-boxBg.night-textColor-2
-     
-     ;; Left sidebar
-     (sidebar/left-sidebar db database)
-     
-     ;; Main content area
-     [:div.main-content-area
-      {:class (when sidebar-collapsed? "sidebar-collapsed")}
-      ;; Back button
-      [:div {:style {:padding "8px 16px"}}
-       [:button
-        {:on-click #(router/go-to-diaries! database)
-         :style {:background "transparent"
-                 :border "1px solid rgba(255,255,255,0.2)"
-                 :color "#fff"
-                 :padding "6px 12px"
-                 :border-radius "4px"
-                 :cursor "pointer"
-                 :font-size "13px"}}
-        "← Back to Diaries"]]
-      [:div.flex.flex-column.overflow-scroll-new
-       {:style {:padding "20px"
-                :max-width "900px"
-                :margin "0 auto"
-                :min-height "100vh"}}
+    [:div.night-center-boxBg.night-textColor-2
+     (sidebar/app-top-bar {:title (if note-info (first note-info) "Note")})
+     [:div.page-wrapper
+      ;; Left sidebar
+      (sidebar/left-sidebar db database)
+      ;; Main content area
+      [:div.main-content-area
+       {:class (when sidebar-collapsed? "sidebar-collapsed")}
+       [:div.flex.flex-column.overflow-scroll-new
+        {:style {:padding "20px"
+                 :max-width "900px"
+                 :margin "0 auto"
+                 :min-height "100vh"}}
 
-       (if note-info
-         (let [[note-title root-nav-id] note-info]
-           [:div
-            ;; Editable note title with context menu
-            [:div.note-title-wrapper
-             {:style {:margin-bottom "24px"}}
-             (note-title-editor note-id note-title root-nav-id database)]
-            
-            ;; Nav outline
-            [:div {:style {:padding-left "12px"}}
-             (render/render-navs db root-nav-id note-id database)]])
-         
-         ;; Note not found
-         [:div.flex.flex-column.items-center.justify-center
-          {:style {:height "50vh"}}
-          [:div {:style {:font-size "18px" :margin-bottom "16px"}} 
-           "Note not found"]
-          [:div {:style {:color "rgba(255,255,255,0.5)" :margin-bottom "20px"}}
-           (str "Note ID: " note-id)]
-          [:button
-           {:on-click #(router/go-to-diaries! database)
-            :style {:background "var(--theme-accent)"
-                    :border "none"
-                    :color "#fff"
-                    :padding "10px 20px"
-                    :border-radius "6px"
-                    :cursor "pointer"}}
-           "Go to Diaries"]])
-       
-       [:div {:style {:height "100px"}}]]]
-     
-     ;; Global title context menu
-     (title-context-menu)
-     
-     ;; Global nav context menu (from render.cljs)
-     (render/global-context-menu)]))
+        (if note-info
+          (let [[note-title root-nav-id] note-info]
+            [:div
+             ;; Editable note title with context menu
+             [:div.note-title-wrapper
+              {:style {:margin-bottom "24px"}}
+              (note-title-editor note-id note-title root-nav-id database)]
+
+             ;; Nav outline
+             [:div {:style {:padding-left "12px"}}
+              (render/render-navs db root-nav-id note-id database)]])
+
+          ;; Note not found
+          [:div.flex.flex-column.items-center.justify-center
+           {:style {:height "50vh"}}
+           [:div {:style {:font-size "18px" :margin-bottom "16px"}}
+            "Note not found"]
+           [:div {:style {:color "rgba(255,255,255,0.5)" :margin-bottom "20px"}}
+            (str "Note ID: " note-id)]
+           [:button
+            {:on-click #(router/go-to-diaries! database)
+             :style {:background "var(--theme-accent)"
+                     :border "none"
+                     :color "#fff"
+                     :padding "10px 20px"
+                     :border-radius "6px"
+                     :cursor "pointer"}}
+            "Go to Diaries"]])
+
+        [:div {:style {:height "100px"}}]]]
+      ;; Global title context menu
+      (title-context-menu)
+      ;; Global nav context menu (from render.cljs)
+      (render/global-context-menu)]]))


### PR DESCRIPTION
## 改动概述

本 PR 主要完成了桌面端页面结构与交互的一轮统一优化，重点是将顶栏升级为全局布局层，并规范图标体系与侧边栏交互。

## 主要改动

### 1. 全局顶栏布局重构

- 将顶栏从内容区内嵌方式调整为应用级全局顶栏（贯穿侧边栏与主内容区上方）。
- 顶栏支持 Electron 拖拽窗口：
  - 顶栏容器使用 `-webkit-app-region: drag`。
  - 交互控件区域使用 `-webkit-app-region: no-drag`。
- 同步调整页面布局关系：
  - `page-wrapper`、`left-sidebar`、`main-content-area` 统一基于顶栏高度进行布局与高度计算。

### 2. Electron 交通灯位置对齐

- 在 macOS 下设置 `trafficLightPosition`，使交通灯按钮与顶栏按钮组更自然对齐。

### 3. 顶栏与侧边栏图标统一

- 接入 Material Symbols（Google Fonts）并在顶栏使用 Symbols 图标。
- 顶栏左/右占位按钮改为：
  - 左侧：`dock_to_right`
  - 右侧：`dock_to_left`
- 侧边栏菜单图标由 Emoji 改为 Material Symbols，统一视觉风格。

### 4. 侧边栏交互调整

- 移除侧边栏原有悬浮展开/折叠按钮。
- 将 `New Note` 按钮移动到侧边栏底部固定操作区域。
- 修复侧边栏菜单激活态导致内容轻微位移的问题：
  - 由 `border-left` 改为 `inset box-shadow`，避免布局宽度变化。

### 5. 页面清理与渲染告警修复

- 移除主内容区中冗余的 Back 按钮（统一使用顶栏导航）。
- 修复 `render-navs` 列表渲染缺少 `key` 的 React 告警。

## 手动验收建议

1. 打开 Diaries / All Notes / Single Note 页面，确认顶栏始终位于最上层并横跨全宽。
2. 在顶栏空白区域拖拽窗口，确认 Electron 窗口可正常移动。
3. 检查顶栏与侧边栏图标是否均为 Material Symbols，且显示正常。
4. 检查侧边栏激活菜单项切换时，文本与图标不再发生横向偏移。
5. 检查 `New Note` 按钮位于侧边栏底部，并可正常创建笔记。

## 影响文件

- `electron/main.js`
- `resources/public/html/hulunote.html`
- `resources/public/css/hulunote.css`
- `src/cljs/hulunote/sidebar.cljs`
- `src/cljs/hulunote/diaries.cljs`
- `src/cljs/hulunote/all_notes.cljs`
- `src/cljs/hulunote/single_note.cljs`
- `src/cljs/hulunote/render.cljs`
