### PR TITLE
feat: 编辑器交互与节点拖拽排序体验优化

### DIFF
--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -31,6 +31,8 @@
     --bullet-size-editing: 8px;
     --note-title-align-left: calc(var(--space-xl) + 4px);
     --app-topbar-height: 56px;
+    --markdown-highlight-bg: rgba(102, 126, 234, 0.3);
+    --markdown-highlight-color: var(--font-color);
 }
 
 body {
@@ -271,6 +273,51 @@ hulu-text-font {
     position: relative;
 }
 
+/* Inline markdown presentation in nav content */
+.markdown-syntax-bold {
+    font-weight: 700;
+}
+
+.markdown-syntax-italics {
+    font-style: italic;
+}
+
+.markdown-syntax-strikethrough {
+    text-decoration: line-through;
+    text-decoration-thickness: 1.5px;
+    opacity: 0.9;
+}
+
+.markdown-syntax-highlight {
+    background: var(--markdown-highlight-bg);
+    color: var(--markdown-highlight-color);
+    border-radius: 3px;
+    padding: 0 2px;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+}
+
+.markdown-heading {
+    display: inline-block;
+    color: var(--font-color);
+    line-height: 1.25;
+}
+
+.markdown-heading-h1 {
+    font-size: 1.5rem;
+    font-weight: 800;
+}
+
+.markdown-heading-h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.markdown-heading-h3 {
+    font-size: 1.125rem;
+    font-weight: 700;
+}
+
 .expand-icon {
     user-select: none;
     font-size: 8px;
@@ -298,11 +345,13 @@ hulu-text-font {
     cursor: text;
     min-width: 100px;
     display: inline-block;
+    min-height: 20px;
+    line-height: 20px;
+    vertical-align: middle;
 }
 
 .nav-content:hover {
-    background: rgba(100, 100, 100, 0.1);
-    border-radius: 3px;
+    background: transparent;
 }
 
 .nav-editor-input {
@@ -315,22 +364,42 @@ hulu-text-font {
     outline: none !important;
     width: 100% !important;
     min-width: 100px !important;
+    height: 20px !important;
+    min-height: 20px !important;
     font: inherit !important;
     font-weight: inherit !important;
     letter-spacing: inherit !important;
-    line-height: inherit !important;
+    line-height: 20px !important;
     text-indent: 0 !important;
     background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
     color: inherit !important;
     box-shadow: none !important;
     margin: 0 !important;
+    vertical-align: middle !important;
+    box-sizing: border-box !important;
 }
 
+.nav-editor-input:hover,
+.nav-editor-input:active,
 .nav-editor-input:focus {
     border: none !important;
     box-shadow: none !important;
     background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
     color: inherit !important;
+}
+
+.nav-editor-input:-webkit-autofill,
+.nav-editor-input:-webkit-autofill:hover,
+.nav-editor-input:-webkit-autofill:focus,
+.nav-editor-input:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 1000px transparent inset !important;
+    -webkit-text-fill-color: inherit !important;
+    background-color: transparent !important;
+    transition: background-color 9999s ease-out 0s;
 }
 
 .night-textColor-2 .nav-editor-input,
@@ -433,9 +502,10 @@ hulu-text-font {
     transition: background 0.1s ease;
     border-radius: 4px;
     align-items: center;
+    position: relative;
 }
 
-.head-dot:hover {
+.head-dot:not(.is-editing):hover {
     background: rgba(255, 255, 255, 0.03);
 }
 
@@ -446,7 +516,38 @@ hulu-text-font {
 }
 
 .head-dot.is-editing {
-    background: rgba(255, 255, 255, 0.05);
+    background: transparent !important;
+}
+
+.head-dot.is-editing:hover {
+    background: transparent !important;
+}
+
+.head-dot.is-editing:focus-within {
+    background: transparent !important;
+}
+
+.head-dot.drop-target-sibling::after,
+.head-dot.drop-target-child::after {
+    content: "";
+    position: absolute;
+    bottom: 1px;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--theme-accent);
+    pointer-events: none;
+}
+
+/* Same-level drop: underline from bullet zone through text to the row end. */
+.head-dot.drop-target-sibling::after {
+    left: 13px;
+    right: 0;
+}
+
+/* Child drop: underline only from text start to the row end. */
+.head-dot.drop-target-child::after {
+    left: 49px; /* row left padding(13) + bullet slot(26) + gap(10) */
+    right: 0;
 }
 
 /* ==================== Daily Note Button ==================== */

--- a/src/cljs/hulunote/components.cljs
+++ b/src/cljs/hulunote/components.cljs
@@ -304,8 +304,24 @@
 (rum/defc parse-and-render
   [string render-params]
   (try
-    (let [result (parser/parse-to-ast string)]
+    (let [heading-match (when (string? string)
+                          (re-matches #"^(#{1,3})\s+(.+)$" string))
+          heading-level (when heading-match
+                          (count (nth heading-match 1)))
+          heading-text (when heading-match
+                         (nth heading-match 2))
+          result (when-not heading-match
+                   (parser/parse-to-ast string))]
       (cond
+        heading-match
+        (let [heading-class (case heading-level
+                              1 "markdown-heading markdown-heading-h1"
+                              2 "markdown-heading markdown-heading-h2"
+                              3 "markdown-heading markdown-heading-h3"
+                              "markdown-heading")]
+          [:span {:class heading-class}
+           (parse-and-render heading-text render-params)])
+
         (insta/failure? result)
         , [:span
            {:title (pr-str (insta/get-failure result))

--- a/src/cljs/hulunote/render.cljs
+++ b/src/cljs/hulunote/render.cljs
@@ -22,6 +22,11 @@
 ;; State for cursor position (used for up/down navigation to maintain column position)
 (defonce target-cursor-column (atom nil))
 
+;; State for drag-and-drop reorder
+(defonce dragging-nav-id (atom nil))
+(defonce drag-over-nav-id (atom nil))
+(defonce drag-over-mode (atom nil))
+
 ;; State for context menu
 (defonce context-menu-state (atom {:visible false
                                     :x 0
@@ -59,7 +64,10 @@
                (max 0 (min cursor-pos len))
                default-pos)]
      (reset! editing-content text)
-     (reset! pending-selection {:nav-id nav-id :pos pos}))))
+     (reset! pending-selection {:nav-id nav-id
+                                :start pos
+                                :end pos
+                                :focus? true}))))
 
 (defn start-editing-at-end!
   "Start editing a nav with cursor at the end"
@@ -127,9 +135,13 @@
   (reset! target-cursor-column nil))
 
 (defn save-nav-content!
-  "Save the edited content of a nav"
-  [nav-id note-id database-name]
-  (let [new-content @editing-content]
+  "Save the edited content of a nav.
+   By default clears editing state; pass {:clear-editing? false} to keep editing."
+  ([nav-id note-id database-name]
+   (save-nav-content! nav-id note-id database-name {:clear-editing? true}))
+  ([nav-id note-id database-name {:keys [clear-editing? content]
+                                  :or {clear-editing? true}}]
+   (let [new-content (if (some? content) content @editing-content)]
     ;; Update local datascript
     (d/transact! db/dsdb
       [[:db/add [:id nav-id] :content new-content]])
@@ -140,8 +152,10 @@
         :note-id note-id
         :id nav-id
         :content new-content}])
-    ;; Clear editing state
-    (cancel-editing!)))
+    ;; Clear editing state only when requested and still editing this nav.
+    (when (and clear-editing?
+               (= nav-id @editing-nav-id))
+      (cancel-editing!)))))
 
 ;; ==================== Context Menu Functions ====================
 
@@ -281,6 +295,27 @@
     (when (and current-idx (< current-idx (dec (count siblings))))
       (nth siblings (inc current-idx)))))
 
+(defn normalize-sibling-orders!
+  "Normalize sibling order values based on current visual sibling sequence.
+   This avoids unstable insert positions when legacy data has duplicate/nil orders."
+  [siblings note-id database-name]
+  (doseq [[idx sibling] (map-indexed vector siblings)]
+    (let [sid (:id sibling)
+          normalized-order (* idx 100)
+          current-order (:same-deep-order sibling)]
+      (when (or (nil? current-order)
+                (not= current-order normalized-order))
+        ;; Update local datascript
+        (d/transact! db/dsdb
+          [[:db/add [:id sid] :same-deep-order normalized-order]])
+        ;; Sync to backend
+        (re-frame/dispatch-sync
+          [:update-nav
+           {:database-name database-name
+            :note-id note-id
+            :id sid
+            :order normalized-order}])))))
+
 (defn calculate-order-between
   "Calculate order value between two orders using midpoint.
    If prev-order is nil, use (next-order / 2).
@@ -307,6 +342,99 @@
         children (:parid nav)]
     (when (seq children)
       (:same-deep-order (last children)))))
+
+(defn collect-descendant-ids
+  "Collect all descendant ids of nav-id."
+  [nav-id]
+  (let [nav (u/get-nav-sub-navs-sorted @db/dsdb nav-id)]
+    (reduce
+      (fn [acc child]
+        (let [cid (:id child)]
+          (into (conj acc cid) (collect-descendant-ids cid))))
+      #{}
+      (:parid nav))))
+
+(defn valid-drop-target?
+  "Validate drop target for moving drag-nav-id onto target-nav-id."
+  [drag-nav-id target-nav-id]
+  (and drag-nav-id
+       target-nav-id
+       (not= drag-nav-id target-nav-id)
+       (not (contains? (collect-descendant-ids drag-nav-id) target-nav-id))))
+
+(defn move-nav-after!
+  "Move drag-nav-id to be the next sibling of target-nav-id."
+  [drag-nav-id target-nav-id note-id database-name]
+  (when (valid-drop-target? drag-nav-id target-nav-id)
+    (let [drag-nav (u/get-nav-by-id @db/dsdb drag-nav-id)
+          target-nav (u/get-nav-by-id @db/dsdb target-nav-id)
+          old-parid (:origin-parid drag-nav)
+          new-parid (:origin-parid target-nav)
+          target-order (or (:same-deep-order target-nav) 0)
+          next-sibling (find-next-sibling target-nav-id)
+          next-order (when next-sibling (:same-deep-order next-sibling))
+          new-order (calculate-order-between target-order next-order)]
+      ;; Update local datascript
+      (when old-parid
+        (d/transact! db/dsdb
+          [[:db/retract [:id old-parid] :parid [:id drag-nav-id]]]))
+      (d/transact! db/dsdb
+        [[:db/add [:id drag-nav-id] :origin-parid new-parid]
+         [:db/add [:id drag-nav-id] :same-deep-order new-order]
+         [:db/add [:id new-parid] :parid [:id drag-nav-id]]])
+      ;; Sync to backend
+      (re-frame/dispatch-sync
+        [:update-nav
+         {:database-name database-name
+          :note-id note-id
+          :id drag-nav-id
+          :parid new-parid
+          :order new-order}]))))
+
+(defn move-nav-to-child!
+  "Move drag-nav-id to be the last child of target-nav-id."
+  [drag-nav-id target-nav-id note-id database-name]
+  (when (valid-drop-target? drag-nav-id target-nav-id)
+    (let [drag-nav (u/get-nav-by-id @db/dsdb drag-nav-id)
+          old-parid (:origin-parid drag-nav)
+          new-parid target-nav-id
+          last-child-order (get-last-child-order new-parid)
+          new-order (calculate-order-between last-child-order nil)]
+      ;; Update local datascript
+      (when old-parid
+        (d/transact! db/dsdb
+          [[:db/retract [:id old-parid] :parid [:id drag-nav-id]]]))
+      (d/transact! db/dsdb
+        [[:db/add [:id drag-nav-id] :origin-parid new-parid]
+         [:db/add [:id drag-nav-id] :same-deep-order new-order]
+         [:db/add [:id new-parid] :parid [:id drag-nav-id]]
+         [:db/add [:id new-parid] :is-display true]])
+      ;; Sync to backend
+      (re-frame/dispatch-sync
+        [:update-nav
+         {:database-name database-name
+          :note-id note-id
+          :id drag-nav-id
+          :parid new-parid
+          :order new-order}])
+      (re-frame/dispatch-sync
+        [:update-nav
+         {:database-name database-name
+          :note-id note-id
+          :id new-parid
+          :is-display true}]))))
+
+(defn detect-drop-mode
+  "Determine drop mode by cursor X relative to target row text left edge.
+   Right of text left edge => child; left zone between bullet and text => sibling."
+  [e]
+  (let [row-el (.-currentTarget e)
+        content-el (when row-el (.querySelector row-el ".nav-content"))
+        text-left (when content-el (.-left (.getBoundingClientRect content-el)))
+        mouse-x (.-clientX e)]
+    (if (and text-left (>= mouse-x text-left))
+      :child
+      :sibling)))
 
 ;; ==================== Visual Navigation Helpers ====================
 ;; These functions help navigate between visible nodes (respecting collapsed state)
@@ -365,12 +493,19 @@
   "Create a new sibling nav after the current one.
    Uses midpoint order calculation."
   [current-nav-id note-id database-name]
-  (let [current-nav (u/get-nav-by-id @db/dsdb current-nav-id)
+  (let [siblings (vec (get-siblings-sorted current-nav-id))
+        _ (normalize-sibling-orders! siblings note-id database-name)
+        current-idx (->> siblings
+                         (map-indexed (fn [i s] [i (:id s)]))
+                         (filter #(= (second %) current-nav-id))
+                         first
+                         first)
+        current-nav (u/get-nav-by-id @db/dsdb current-nav-id)
         parid (or (:origin-parid current-nav) db/root-id)
-        current-order (or (:same-deep-order current-nav) 0)
-        next-sibling (find-next-sibling current-nav-id)
-        next-order (when next-sibling (:same-deep-order next-sibling))
-        ;; Calculate new order as midpoint between current and next
+        current-order (if (some? current-idx) (* current-idx 100) 0)
+        next-order (when (and current-idx (< current-idx (dec (count siblings))))
+                     (* (inc current-idx) 100))
+        ;; Calculate new order as midpoint between normalized neighbors
         new-order (calculate-order-between current-order next-order)
         new-nav-id (str (d/squuid))]
     ;; Create in local datascript first
@@ -382,6 +517,8 @@
         :is-display true
         :origin-parid parid}
        [:db/add [:id parid] :parid [:id new-nav-id]]])
+    ;; Enter edit mode immediately to avoid idle-state flash on the new node.
+    (start-editing! new-nav-id "")
     ;; Sync to backend
     (re-frame/dispatch-sync
       [:create-nav
@@ -390,9 +527,48 @@
         :id new-nav-id
         :parid parid
         :content ""
-        :order new-order}])
-    ;; Start editing the new nav
-    (start-editing! new-nav-id "")))
+        :order new-order}])))
+
+(defn create-sibling-above!
+  "Create a new sibling nav before the current one."
+  [current-nav-id note-id database-name]
+  (let [siblings (vec (get-siblings-sorted current-nav-id))
+        _ (normalize-sibling-orders! siblings note-id database-name)
+        current-idx (->> siblings
+                         (map-indexed (fn [i s] [i (:id s)]))
+                         (filter #(= (second %) current-nav-id))
+                         first
+                         first)
+        current-nav (u/get-nav-by-id @db/dsdb current-nav-id)
+        parid (or (:origin-parid current-nav) db/root-id)
+        current-order (if (some? current-idx) (* current-idx 100) 0)
+        prev-order (when (and current-idx (> current-idx 0))
+                     (* (dec current-idx) 100))
+        ;; For first sibling, use a stable order before current.
+        new-order (if (some? prev-order)
+                    (calculate-order-between prev-order current-order)
+                    (- current-order 100))
+        new-nav-id (str (d/squuid))]
+    ;; Create in local datascript first
+    (d/transact! db/dsdb
+      [{:id new-nav-id
+        :content ""
+        :hulunote-note note-id
+        :same-deep-order new-order
+        :is-display true
+        :origin-parid parid}
+       [:db/add [:id parid] :parid [:id new-nav-id]]])
+    ;; Enter edit mode immediately to avoid idle-state flash on the new node.
+    (start-editing! new-nav-id "")
+    ;; Sync to backend
+    (re-frame/dispatch-sync
+      [:create-nav
+       {:database-name database-name
+        :note-id note-id
+        :id new-nav-id
+        :parid parid
+        :content ""
+        :order new-order}])))
 
 (defn indent-nav!
   "Indent a nav (make it a child of its previous sibling).
@@ -479,6 +655,32 @@
                  @db/dsdb note-id)]
       (:hulunote-notes/root-nav-id note))))
 
+(defn apply-inline-wrap!
+  "Wrap current selection with marker, or insert paired markers for collapsed caret."
+  [input marker]
+  (let [content @editing-content
+        marker-len (count marker)
+        start (or (.-selectionStart input) 0)
+        end (or (.-selectionEnd input) start)
+        [from to] (if (<= start end) [start end] [end start])
+        selected (subs content from to)
+        new-content (str (subs content 0 from)
+                         marker
+                         selected
+                         marker
+                         (subs content to))
+        collapsed? (= from to)
+        new-start (+ from marker-len)
+        new-end (if collapsed?
+                  new-start
+                  (+ new-start (count selected)))]
+    (reset! editing-content new-content)
+    (js/setTimeout
+      (fn []
+        (.focus input)
+        (.setSelectionRange input new-start new-end))
+      0)))
+
 (defn handle-key-down
   "Handle keyboard events in edit mode.
    - Arrow Up/Down: navigate between visible nodes (like editing a document)
@@ -491,14 +693,39 @@
    - Backspace/Delete: delete node when content is empty"
   [e nav-id note-id database-name]
   (let [key-code (.-keyCode e)
+        key (.-key e)
+        mod? (or (.-metaKey e) (.-ctrlKey e))
         shift? (.-shiftKey e)
         saved-content @editing-content
-        current-content @editing-content
         input (.-target e)
+        current-content (or (.-value input) @editing-content)
         cursor-pos (.-selectionStart input)
         content-length (count current-content)
         root-nav-id (get-root-nav-id note-id)]
+    ;; Prevent global key handlers from stealing focus while editing.
+    (.stopPropagation e)
     (cond
+      ;; Cmd/Ctrl + B/I/Y/H - inline markdown styling
+      (and mod? (#{"b" "B"} key))
+      (do
+        (.preventDefault e)
+        (apply-inline-wrap! input "**"))
+
+      (and mod? (#{"i" "I"} key))
+      (do
+        (.preventDefault e)
+        (apply-inline-wrap! input "__"))
+
+      (and mod? (#{"y" "Y"} key))
+      (do
+        (.preventDefault e)
+        (apply-inline-wrap! input "~~"))
+
+      (and mod? (#{"h" "H"} key))
+      (do
+        (.preventDefault e)
+        (apply-inline-wrap! input "^^"))
+
       ;; Arrow Up (38) - move to previous visible node
       (= key-code 38)
       (when-let [prev-nav (get-prev-visible-nav root-nav-id nav-id)]
@@ -559,8 +786,9 @@
       (or (= key-code 37) (= key-code 39))
       (reset! target-cursor-column nil)
       
-      ;; Backspace key (8) or Delete key (46) - delete node when content is empty
-      (and (or (= key-code 8) (= key-code 46))
+      ;; Backspace key (8) - delete node when content is empty
+      ;; Keep Delete key for text editing to avoid accidental exit from edit mode.
+      (and (= key-code 8)
            (empty? current-content))
       (do
         (.preventDefault e)
@@ -590,20 +818,20 @@
       (and (= key-code 9) (not shift?))
       (do
         (.preventDefault e)
-        (save-nav-content! nav-id note-id database-name)
+        (save-nav-content! nav-id note-id database-name {:clear-editing? false})
         (js/setTimeout
           #(do (indent-nav! nav-id note-id database-name)
-               (start-editing! nav-id saved-content))
+               (start-editing! nav-id saved-content cursor-pos))
           50))
       
       ;; Shift+Tab - outdent (make sibling of parent)
       (and (= key-code 9) shift?)
       (do
         (.preventDefault e)
-        (save-nav-content! nav-id note-id database-name)
+        (save-nav-content! nav-id note-id database-name {:clear-editing? false})
         (js/setTimeout
           #(do (outdent-nav! nav-id note-id database-name)
-               (start-editing! nav-id saved-content))
+               (start-editing! nav-id saved-content cursor-pos))
           50))
       
       ;; Enter key - save and create new sibling
@@ -611,10 +839,15 @@
       (do
         (.preventDefault e)
         (reset! target-cursor-column nil)
-        (save-nav-content! nav-id note-id database-name)
+        ;; Keep editing state during create flow to avoid visual flicker.
+        (save-nav-content! nav-id note-id database-name {:clear-editing? false})
+        ;; Defer create+focus to next tick to avoid blur/keydown timing race.
         (js/setTimeout
-          #(create-sibling-nav! nav-id note-id database-name)
-          50))
+          #(if (and (= cursor-pos 0)
+                    (not (empty? current-content)))
+             (create-sibling-above! nav-id note-id database-name)
+             (create-sibling-nav! nav-id note-id database-name))
+          0)))
       
       ;; Escape key - cancel
       (= key-code 27)
@@ -624,7 +857,17 @@
       :else
       (when (and (not (#{37 38 39 40} key-code)) ; not arrow keys
                  (not (#{16 17 18 91} key-code))) ; not modifier keys
-        (reset! target-cursor-column nil)))))
+        (reset! target-cursor-column nil))))
+
+(defn should-handle-editor-key?
+  "Run custom keyboard handler only for control/navigation/markdown shortcut keys."
+  [e]
+  (let [key-code (.-keyCode e)
+        key (.-key e)
+        mod? (or (.-metaKey e) (.-ctrlKey e))
+        markdown-shortcut? (and mod? (#{"b" "B" "i" "I" "y" "Y" "h" "H"} key))
+        control-key? (contains? #{8 9 13 27 37 38 39 40} key-code)]
+    (or markdown-shortcut? control-key?)))
 
 ;; ==================== UI Components ====================
 
@@ -651,6 +894,22 @@
               :gap "7px"
               :border-radius "8px"
               :height "16px"}
+      :draggable (not is-editing)
+      :on-drag-start (fn [e]
+                       (.stopPropagation e)
+                       (set! (.. e -dataTransfer -effectAllowed) "move")
+                       (.setData (.-dataTransfer e) "text/plain" nav-id)
+                       (reset! dragging-nav-id nav-id)
+                       (reset! drag-over-nav-id nil)
+                       (reset! drag-over-mode nil))
+      :on-drag-end (fn [e]
+                     (.stopPropagation e)
+                     (reset! drag-over-nav-id nil)
+                     (reset! drag-over-mode nil)
+                     (reset! dragging-nav-id nil))
+      :on-click (fn [e]
+                  ;; Bullet area should not trigger row editing click.
+                  (u/stop-click-bubble e))
       :on-context-menu (fn [e]
                          (show-context-menu! e nav-id content note-id database-name))}
      ;; Keep a stable slot before the dot; show triangle only for nodes with children.
@@ -698,10 +957,12 @@
        {:type "text"
         :value (rum/react editing-content)
         :ref (fn [el]
-               (when-let [{:keys [nav-id pos]} @pending-selection]
+               (when-let [{:keys [nav-id start end focus?]} @pending-selection]
                  (when (and el (= nav-id @editing-nav-id))
-                   (.focus el)
-                   (.setSelectionRange el pos pos)
+                   ;; Keep focus in editor across controlled rerenders.
+                   (when (not= (.-activeElement js/document) el)
+                     (.focus el))
+                   (.setSelectionRange el start end)
                    (reset! pending-selection nil))))
         :style {:border "none"
                 :border-radius "0"
@@ -716,16 +977,39 @@
                 :line-height "inherit"
                 :background "transparent"
                 :color "inherit"}
-        :on-change #(reset! editing-content (.. % -target -value))
-        :on-key-down #(handle-key-down % nav-id note-id database-name)
-        :on-blur #(save-nav-content! nav-id note-id database-name)}]
+        :on-change (fn [e]
+                     (let [input (.-target e)
+                           value (.-value input)
+                       start (or (.-selectionStart input) 0)
+                       end (or (.-selectionEnd input) start)]
+                       ;; Keep caret stable across controlled-input rerenders.
+                       (reset! pending-selection {:nav-id nav-id
+                                                  :start start
+                                                  :end end
+                                                  :focus? true})
+                       (reset! editing-content value)))
+        :on-key-down (fn [e]
+                       ;; Always isolate editor key events from global handlers.
+                       (.stopPropagation e)
+                       (let [key-code (.-keyCode e)
+                             input-value (or (.. e -target -value) "")]
+                         (when (or (= key-code 9) ; Tab
+                                   (= key-code 13) ; Enter
+                                   (and (= key-code 8) ; Backspace
+                                        (empty? input-value)))
+                           (handle-key-down e nav-id note-id database-name))))
+        :on-blur (fn [_] nil)}]
       [:span.nav-content
        {:style {:cursor "text"
                 :min-height "20px"
                 :display "inline-block"
-                :min-width "100px"}}
-       (if (empty? content)
-         [:span {:style {:color "#666"}} "Click to edit..."]
+                :min-width "100px"}
+        :on-click (fn [e]
+                    (u/stop-click-bubble e)
+                    (reset! target-cursor-column nil)
+                    (let [cursor-pos (estimate-cursor-pos-from-click e content)]
+                      (start-editing! nav-id content cursor-pos)))}
+       (when-not (empty? content)
          (comps/parse-and-render content {}))])))
 
 (rum/defc nav-input < rum/reactive
@@ -735,20 +1019,48 @@
                 properties same-deep-order updated-at
                 created-at last-user-cursor]}
         (u/get-nav-by-id db id)
-        is-editing (= id (rum/react editing-nav-id))]
+        is-editing (= id (rum/react editing-nav-id))
+        is-drop-target (= id (rum/react drag-over-nav-id))
+        current-drop-mode (rum/react drag-over-mode)]
     [:div.nav-item
      ;; Entire row is clickable to enter edit mode
-     [:div {:class (str "head-dot flex " (when is-editing "is-editing"))
+     [:div {:class (str "head-dot flex "
+                        (when is-editing "is-editing")
+                        (when is-drop-target
+                          (str " "
+                               (if (= current-drop-mode :child)
+                                 "drop-target-child"
+                                 "drop-target-sibling"))))
             :style {:padding-left "13px"
                     :padding-top "5px"
                     :padding-bottom "5px"
                     :cursor "text"}
+            :on-drag-over (fn [e]
+                            (when (valid-drop-target? @dragging-nav-id id)
+                              (.preventDefault e)
+                              (set! (.. e -dataTransfer -dropEffect) "move")
+                              (reset! drag-over-nav-id id)
+                              (reset! drag-over-mode (detect-drop-mode e))))
+            :on-drag-leave (fn [_]
+                             (when (= id @drag-over-nav-id)
+                               (reset! drag-over-nav-id nil)
+                               (reset! drag-over-mode nil)))
+            :on-drop (fn [e]
+                       (.preventDefault e)
+                       (.stopPropagation e)
+                       (let [drag-id (or @dragging-nav-id
+                                         (.getData (.-dataTransfer e) "text/plain"))
+                             mode (or @drag-over-mode (detect-drop-mode e))]
+                         (if (= mode :child)
+                           (move-nav-to-child! drag-id id note-id database-name)
+                           (move-nav-after! drag-id id note-id database-name)))
+                       (reset! drag-over-nav-id nil)
+                       (reset! drag-over-mode nil)
+                       (reset! dragging-nav-id nil))
             :on-click (fn [e]
-                        ;; Only start editing if not clicking on bullet
-                        (when-not (.. e -target -classList (contains "controls"))
-                          (reset! target-cursor-column nil)
-                          (let [cursor-pos (estimate-cursor-pos-from-click e content)]
-                            (start-editing! id content cursor-pos))))}
+                        (reset! target-cursor-column nil)
+                        (let [cursor-pos (estimate-cursor-pos-from-click e content)]
+                          (start-editing! id content cursor-pos)))}
       (nav-bullet db id is-display note-id database-name content is-editing)
       (nav-content-editor id content note-id database-name)]
      (when is-display


### PR DESCRIPTION
## 变更摘要
本 PR 聚焦桌面端大纲编辑器的连续交互体验，包含 Markdown 样式能力补齐、回车/删除/缩进行为修复、以及节点拖拽重排能力（含 Roam 风格判定与可视化提示）。

## 主要改动
### 1) 编辑器 Markdown 样式支持
- 新增快捷包裹逻辑（输入框内选区/光标位）。
- 支持语法：
  - `**加粗**`
  - `__斜体__`
  - `~~删除线~~`
  - `^^高亮^^`
- 补齐对应渲染样式与视觉统一。

### 2) 标题语法渲染
- 新增 `# / ## / ###` 三档标题样式渲染。
- 采用渲染层识别方案，减少 parser 侧变更风险。

### 3) 编辑交互稳定性修复
- 修复进入编辑时行高/位置跳动问题。
- 去除空节点占位文案闪烁。
- 修复空节点与行首回车上插规则冲突：
  - 非空节点且光标在行首：在上方创建同级节点。
  - 空节点回车：在下方创建并进入新节点编辑。
- 修复部分节点回车新建位置错误（会跳到底部）的问题。

### 4) 节点拖拽排序（小圆点拖拽）
- 支持通过小圆点拖拽节点重排。
- 放置判定：
  - 拖到目标文字左边界右侧：作为目标子节点。
  - 拖到小圆点与文字之间：作为目标同级（目标后）。
- 增加两种下划线放置提示：
  - 子节点模式：文字起点到行尾。
  - 同级模式：小圆点区域到行尾。
- 增加非法放置保护（禁止拖到自己/后代，避免循环结构）。

### 5) 删除与输入行为修复
- 空节点按删除键可删节点。
- 非空节点删除键恢复为正常删字。
- 保持回车新建、Tab/Shift+Tab 缩进/反缩进可用。

## 修改文件
- `src/cljs/hulunote/render.cljs`
- `src/cljs/hulunote/components.cljs`
- `resources/public/css/hulunote.css`

## 验收说明（人工）
1. 编辑稳定性
- 点击任意节点可进入编辑并持续输入。
- 非空节点删除键可删字；空节点删除键可删节点。

2. 回车与缩进
- 回车可创建新节点并自动进入新节点。
- 行首回车在非空节点上方创建同级。
- Tab/Shift+Tab 缩进与反缩进正常。

3. Markdown 语法
- `**`、`__`、`~~`、`^^` 渲染符合预期。
- `# / ## / ###` 三档标题渲染符合预期。

4. 拖拽排序
- 仅小圆点可拖拽。
- 同级/子级放置判定与下划线提示正确。
- 拖拽后层级与顺序正确，且无循环结构。
