### PR TITLE
fix: polish app topbar and sidebar behavior

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -43,10 +43,6 @@ function createWindow() {
       webSecurity: !isDev
     },
     icon: path.join(__dirname, 'icons', 'icon.png'),
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
-    ...(process.platform === 'darwin'
-      ? { trafficLightPosition: { x: 14, y: 18 } }
-      : {}),
     show: false,
     backgroundColor: '#ffffff'
   });

--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -592,6 +592,12 @@ hulu-text-font {
     transform: translateX(-100%);
 }
 
+.left-sidebar.collapsed.peek-open {
+    transform: translateX(0);
+    box-shadow: 12px 0 32px rgba(0, 0, 0, 0.28);
+    z-index: 140;
+}
+
 .sidebar-toggle-btn {
     position: fixed;
     left: var(--sidebar-width);
@@ -638,6 +644,10 @@ hulu-text-font {
     flex: 1;
     overflow-y: auto;
     padding: 8px 0;
+}
+
+.left-sidebar:not(.collapsed) .sidebar-content {
+    padding-top: 16px;
 }
 
 .sidebar-item {
@@ -760,7 +770,7 @@ hulu-text-font {
 
 .main-content-area.sidebar-collapsed {
     margin-left: 0;
-    padding-left: 40px;
+    padding-left: 24px;
 }
 
 /* ==================== App Top Bar ==================== */
@@ -771,8 +781,8 @@ hulu-text-font {
     left: 0;
     right: 0;
     z-index: 90;
-    height: 56px;
-    padding: 0 16px 0 16px;
+    height: 48px;
+    padding: 0 14px;
     display: grid;
     grid-template-columns: auto 1fr auto;
     align-items: center;
@@ -780,6 +790,36 @@ hulu-text-font {
     background: rgba(46, 51, 64, 0.94);
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(8px);
+}
+
+.app-topbar.with-sidebar {
+    grid-template-columns: var(--sidebar-width) auto 1fr auto;
+    padding-left: 0;
+    gap: 4px;
+}
+
+.app-topbar-brand {
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 16px;
+    box-sizing: border-box;
+}
+
+.app-topbar-brand-main {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.app-topbar-brand-text {
+    font-size: 16px;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
 }
 
 .app-topbar-left,
@@ -790,7 +830,15 @@ hulu-text-font {
 }
 
 .app-topbar-left {
-    padding-left: 8px;
+    padding-left: 2px;
+}
+
+.app-topbar.with-sidebar .app-topbar-left {
+    padding-left: 0;
+}
+
+.app-topbar.with-sidebar .app-topbar-brand {
+    padding-right: 8px;
 }
 
 /* When running inside Electron on macOS, add extra padding for traffic lights */
@@ -828,8 +876,8 @@ hulu-text-font {
 }
 
 .app-topbar-btn {
-    width: 28px;
-    height: 28px;
+    width: 26px;
+    height: 26px;
     border-radius: 6px;
     border: 1px solid transparent;
     background: transparent;
@@ -845,8 +893,8 @@ hulu-text-font {
 }
 
 .app-topbar-icon {
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
     filter: invert(1) brightness(0.85);
 }
 

--- a/src/cljs/hulunote/database.cljs
+++ b/src/cljs/hulunote/database.cljs
@@ -342,18 +342,15 @@
               :background "#f8f9fa"}
       :on-click #(swap! context-menu-state assoc :visible false)}
      
-     ;; Header (with macOS traffic light padding)
+     ;; Header
      [:div.td-navbar
       {:style {:display "flex"
                :align-items "center"
                :justify-content "space-between"
                :padding "0 32px"
-               :padding-top "28px"
                :height "60px"
-               :background "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
-               :-webkit-app-region "drag"}}
+               :background "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"}}
       [:div.flex.items-center
-       {:style {:-webkit-app-region "no-drag"}}
        [:img.pointer
         {:on-click #(router/switch-router! "/main")
          :width "36px"

--- a/src/cljs/hulunote/sidebar.cljs
+++ b/src/cljs/hulunote/sidebar.cljs
@@ -10,12 +10,40 @@
 
 ;; State for sidebar collapse
 (defonce sidebar-collapsed? (atom false))
+(defonce sidebar-peek-open? (atom false))
+(defonce sidebar-peek-timeout (atom nil))
 
 ;; State to track if we've already created today's note this session
 (defonce daily-note-created? (atom #{}))
 
+(defn clear-sidebar-peek-timeout! []
+  (when-let [timeout-id @sidebar-peek-timeout]
+    (js/clearTimeout timeout-id)
+    (reset! sidebar-peek-timeout nil)))
+
+(defn open-sidebar-peek! []
+  (when @sidebar-collapsed?
+    (clear-sidebar-peek-timeout!)
+    (reset! sidebar-peek-open? true)))
+
+(defn close-sidebar-peek! []
+  (clear-sidebar-peek-timeout!)
+  (reset! sidebar-peek-open? false))
+
+(defn schedule-sidebar-peek-close! []
+  (when @sidebar-collapsed?
+    (clear-sidebar-peek-timeout!)
+    (reset! sidebar-peek-timeout
+      (js/setTimeout
+        (fn []
+          (reset! sidebar-peek-open? false)
+          (reset! sidebar-peek-timeout nil))
+        140))))
+
 (defn toggle-sidebar! []
-  (swap! sidebar-collapsed? not))
+  (clear-sidebar-peek-timeout!)
+  (swap! sidebar-collapsed? not)
+  (reset! sidebar-peek-open? false))
 
 (defn generate-note-title
   "Generate a unique note title with date and time"
@@ -225,17 +253,28 @@
    [:div.sidebar-item-icon icon]
    [:div.sidebar-item-text text]])
 
-(rum/defc app-top-bar
-  "Global top bar - only visible in Electron client."
-  [{:keys [title]}]
-  (when (u/is-electron?)
+(rum/defc app-top-bar < rum/reactive
+  "Global top bar for app pages."
+   [_]
+  (let [collapsed? (rum/react sidebar-collapsed?)]
     ;; Set topbar height on :root so layout (sidebar, page-wrapper) adapts
-    (.setProperty (.-style (.-documentElement js/document)) "--app-topbar-height" "56px")
+    (.setProperty (.-style (.-documentElement js/document)) "--app-topbar-height" "48px")
     [:div.app-topbar
-   [:div.app-topbar-left
+     {:class (when-not collapsed? "with-sidebar")}
+     (when-not collapsed?
+       [:div.app-topbar-brand
+        [:div.app-topbar-brand-main
+         [:img {:src (u/asset-path "/img/hulunote.webp")
+                :width "28px"
+                :height "28px"
+                :style {:border-radius "50%"}}]
+         [:span.app-topbar-brand-text "HULUNOTE"]]])
+     [:div.app-topbar-left
     [:button.app-topbar-btn
-     {:title "Toggle Sidebar"
-      :on-click toggle-sidebar!}
+     {:title (if collapsed? "Show Sidebar" "Hide Sidebar")
+      :on-click toggle-sidebar!
+      :on-mouse-enter open-sidebar-peek!
+      :on-mouse-leave schedule-sidebar-peek-close!}
      [:img.app-topbar-icon {:src (u/asset-path "/img/icons/dock_to_right.svg")}]]
     [:button.app-topbar-btn
      {:title "Back"
@@ -245,9 +284,7 @@
      {:title "Forward"
       :on-click #(js/history.forward)}
      [:img.app-topbar-icon {:src (u/asset-path "/img/icons/arrow_forward.svg")}]]]
-   [:div.app-topbar-center
-    [:div.app-topbar-tab.active
-     (or title "Untitled")]]
+   [:div.app-topbar-center]
    [:div.app-topbar-right
     [:button.app-topbar-btn
      {:title "Search (placeholder)"
@@ -257,22 +294,29 @@
 (rum/defc left-sidebar < rum/reactive
   [db database-name]
   (let [collapsed? (rum/react sidebar-collapsed?)
+        peek-open? (rum/react sidebar-peek-open?)
+        visible? (or (not collapsed?) peek-open?)
         daily-list (db/sort-daily-list (db/get-daily-list db))
         {:keys [route-name]} (db/get-route db)]
-    [:<>
-     ;; Sidebar container
-     [:div.left-sidebar
-      {:class (when collapsed? "collapsed")}
+    [:div.left-sidebar
+     {:class (str
+               (when collapsed? " collapsed")
+               (when peek-open? " peek-open"))
+      :on-mouse-enter #(when collapsed?
+                         (open-sidebar-peek!))
+      :on-mouse-leave #(when collapsed?
+                         (close-sidebar-peek!))}
 
-      (when-not collapsed?
+     (when visible?
         [:<>
-         ;; Sidebar header with logo
-         [:div.sidebar-header
-          [:div.flex.items-center
-           [:img {:src (u/asset-path "/img/hulunote.webp")
-                  :width "24px"
-                  :style {:border-radius "50%"}}]
-           [:span.sidebar-title.ml2 "HULUNOTE"]]]
+         ;; Sidebar header with logo only in temporary peek mode
+         (when collapsed?
+           [:div.sidebar-header
+            [:div.flex.items-center
+             [:img {:src (u/asset-path "/img/hulunote.webp")
+                    :width "24px"
+                    :style {:border-radius "50%"}}]
+             [:span.sidebar-title.ml2 "HULUNOTE"]]])
 
          ;; Today's Daily Note button
          [:button.daily-note-btn
@@ -338,16 +382,9 @@
           {:style {:padding "12px 16px"
                    :border-top "1px solid rgba(255, 255, 255, 0.08)"
                    :flex-shrink 0}}
-          [:button.new-note-btn
+         [:button.new-note-btn
            {:style {:margin "0"
                     :width "100%"}
             :on-click #(create-new-note! database-name)}
            [:span.new-note-btn-icon "+"]
-           "New Note"]]])]
-
-     ;; Toggle button - always visible, positioned at edge of sidebar
-     [:div.sidebar-toggle-btn
-      {:class (when collapsed? "collapsed")
-       :on-click toggle-sidebar!
-       :title (if collapsed? "Show Sidebar" "Hide Sidebar")}
-      (if collapsed? "☰" "✕")]]))
+           "New Note"]]])]))


### PR DESCRIPTION
## 概要
这次主要整理了 app 页面里顶栏和侧边栏的关系，让网页端和 Electron 端使用同一套页面级导航结构。

## 改动
- 移除 Electron 窗口层额外的标题栏样式
- 将 app 顶栏统一收口到 web 页面内渲染
- 优化侧边栏展开/折叠后的顶栏布局
- 增加折叠状态下的 hover 临时展开侧边栏交互
- 微调顶栏高度、按钮间距和品牌区位置

## 验证
- 在浏览器开发环境下确认展开、折叠、hover peek 行为正常
- 在 Electron 开发环境下确认界面与网页端一致

麦先生