### PR TITLE
优化反向链接面板样式与交互

### DIFF
--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -29,7 +29,8 @@
     --bullet-collapsed-glow: rgba(216, 216, 216, 0.28);
     --bullet-size-idle: 5px;
     --bullet-size-editing: 8px;
-    --note-title-align-left: calc(var(--space-xl) + 4px);
+    --note-content-align-left: 34px;
+    --note-title-align-left: var(--note-content-align-left);
     --app-topbar-height: 0px;
     --markdown-highlight-bg: rgba(102, 126, 234, 0.3);
     --markdown-highlight-color: var(--font-color);
@@ -509,6 +510,20 @@ hulu-text-font {
     background: rgba(255, 255, 255, 0.03);
 }
 
+.backlink-outline-node:not(.is-editing):hover {
+    background: transparent;
+}
+
+.backlink-note-link-title {
+    text-decoration: none;
+}
+
+.backlink-note-link-title:hover {
+    text-decoration: underline;
+    text-decoration-style: solid;
+    cursor: pointer;
+}
+
 .head-dot:hover .expand-icon {
     opacity: 1;
     visibility: visible;
@@ -766,11 +781,13 @@ hulu-text-font {
     overflow-y: auto;
     padding-top: 0;
     padding-left: 40px;
+    padding-right: 40px;
 }
 
 .main-content-area.sidebar-collapsed {
     margin-left: 0;
     padding-left: 24px;
+    padding-right: 24px;
 }
 
 /* ==================== App Top Bar ==================== */

--- a/src/cljs/hulunote/single_note.cljs
+++ b/src/cljs/hulunote/single_note.cljs
@@ -6,7 +6,6 @@
             [hulunote.db :as db]
             [hulunote.sidebar :as sidebar]
             [hulunote.router :as router]
-            [hulunote.components :as comps]
             [re-frame.core :as re-frame]))
 
 ;; State for editing note title
@@ -264,17 +263,42 @@
 (defonce backlinks-collapsed? (atom {}))
 
 (rum/defc backlink-nav-item
-  "Render a single backlinked nav block with its parsed content"
-  [nav]
+  "Render a single backlinked nav block using the same editor behavior as normal outline nodes"
+  [source-note-id database-name nav]
   [:div.backlink-nav-item
-   {:style {:padding "6px 12px"
-            :margin "4px 0"
-            :background "rgba(255,255,255,0.03)"
-            :border-radius "4px"
-            :border-left "3px solid var(--theme-accent, #5c7cfa)"
-            :font-size "14px"
-            :line-height "1.6"}}
-   (comps/parse-and-render (:content nav) {})])
+   [:div {:class "head-dot flex backlink-outline-node"
+          :style {:padding-left "13px"
+                  :padding-top "5px"
+                  :padding-bottom "5px"
+                  :cursor "default"}}
+    [:span
+     {:class "controls hulu-text-font"
+      :style {:align-items "center"
+              :vertical-align "middle"
+              :width "26px"
+              :cursor "default"
+              :padding-left "0"
+              :justify-content "flex-start"
+              :display "flex"
+              :margin-right "10px"
+              :gap "7px"
+              :border-radius "8px"
+              :height "16px"}}
+     [:span
+      {:style {:width "9px"
+               :display "inline-flex"
+               :justify-content "center"}}]
+     [:span
+      {:class "controls customize-dot night-circular"
+       :style {:height "var(--bullet-size-idle)"
+               :width "var(--bullet-size-idle)"
+               :border-radius "50%"
+               :background-color "var(--bullet-idle-color)"
+               :box-shadow "none"
+               :cursor "default"
+               :display "block"
+               :vertical-align "middle"}}]]
+    (render/nav-content-editor (:id nav) (:content nav) source-note-id database-name)]])
 
 (rum/defc backlink-note-group < rum/reactive
   "Render a group of backlinks from a single source note"
@@ -287,9 +311,9 @@
      [:div.backlink-note-title
       {:style {:display "flex"
                :align-items "center"
-               :gap "6px"
-               :cursor "pointer"
-               :padding "6px 8px"
+               :gap "10px"
+               :cursor "default"
+               :padding "6px 0"
                :border-radius "4px"}
        :on-click (fn [e]
                    (u/stop-click-bubble e)
@@ -299,14 +323,14 @@
                       :color "rgba(255,255,255,0.4)"
                       :transition "transform 0.15s"
                       :display "inline-block"
+                      :cursor "pointer"
                       :transform (if collapsed? "rotate(0deg)" "rotate(90deg)")}}
        "\u25B6"]
       ;; Note title link (shift+click opens in right sidebar)
-      [:span {:style {:color "var(--theme-accent, #5c7cfa)"
-                      :font-weight "500"
+      [:span {:class "backlink-note-link-title"
+              :style {:font-weight "500"
                       :font-size "14px"
-                      :text-decoration "underline"
-                      :text-decoration-style "dotted"}
+                      :color "rgba(255,255,255,0.78)"} 
               :on-click (fn [e]
                           (u/stop-click-bubble e)
                           (if (.-shiftKey e)
@@ -320,16 +344,21 @@
                             (router/go-to-note! database-name source-note-id)))}
        source-title]
       ;; Count badge
-      [:span {:style {:font-size "11px"
+      [:span {:style {:display "inline-flex"
+                      :align-items "center"
+                      :font-size "11px"
+                      :line-height "1"
                       :color "rgba(255,255,255,0.4)"
                       :margin-left "4px"}}
        (str (count navs))]]
      ;; Nav content blocks
      (when-not collapsed?
        [:div.backlink-navs
-        {:style {:padding-left "20px"}}
+        {:style {:padding-left "0"}}
         (for [nav navs]
-          (rum/with-key (backlink-nav-item nav) (:id nav)))])]))
+          (rum/with-key
+            (backlink-nav-item source-note-id database-name nav)
+            (:id nav)))])]))
 
 (rum/defc linked-references < rum/reactive
   "Linked References panel - shows all notes that reference the current note"
@@ -342,6 +371,7 @@
     (when (pos? total-count)
       [:div.linked-references
        {:style {:margin-top "40px"
+                :margin-left "var(--note-content-align-left)"
                 :padding-top "20px"
                 :border-top "1px solid rgba(255,255,255,0.1)"}}
        ;; Section header
@@ -353,13 +383,7 @@
         [:span {:style {:font-size "15px"
                         :font-weight "600"
                         :color "rgba(255,255,255,0.7)"}}
-         "Linked References"]
-        [:span {:style {:font-size "12px"
-                        :color "rgba(255,255,255,0.4)"
-                        :background "rgba(255,255,255,0.08)"
-                        :padding "2px 8px"
-                        :border-radius "10px"}}
-         (str total-count)]]
+         (str total-count " Linked References")]]
        ;; Grouped backlinks
        [:div.linked-references-body
         (for [[source-note-id {:keys [title note-id navs]}] grouped]


### PR DESCRIPTION
## 概述
- 统一单篇笔记内容区与反向链接区域的左侧对齐
- 优化反向链接头部、来源标题和节点展示样式
- 让反向链接中的被引用节点支持与正文一致的点击编辑

## 为什么要改
- 原有反向链接区域与正文左边界不一致，视觉上割裂
- 反向链接中的引用内容使用引用框样式，与正文大纲节点风格不统一
- 来源标题默认呈现为链接样式，层级和交互提示不够自然

## 具体改动
- 抽出统一的 note content left rail，并让反向链接区域与标题、正文对齐
- 修正主内容区在窄宽度下左右留白不对称的问题
- 将 Linked References 头部数量改为标题内文本形式，例如 1 Linked References
- 调整来源笔记标题的默认和悬停样式：默认普通标题，悬停显示下划线和手型
- 将反向链接中的被引用内容改为正文式大纲节点展示，去掉悬停背景框
- 复用正文的 nav-content-editor，支持直接点击编辑反向链接节点内容

## 验证
- 运行 npx shadow-cljs watch hulunote
- 页面编译通过，无新增编译错误
- 在单篇笔记页确认了反向链接区域的对齐、标题样式和节点编辑行为
