### PR TITLE
优化 Diaries 页面滚动、间距与标题交互

### DIFF
--- a/resources/public/css/hulunote.css
+++ b/resources/public/css/hulunote.css
@@ -31,6 +31,10 @@
     --bullet-size-editing: 8px;
     --note-content-align-left: 34px;
     --note-title-align-left: var(--note-content-align-left);
+    --diary-entry-padding-top: 40px;
+    --diary-entry-padding-bottom: 80px;
+    --diary-entry-gap: 18px;
+    --diary-entry-divider: rgba(151, 151, 151, 0.25);
     --app-topbar-height: 0px;
     --markdown-highlight-bg: rgba(102, 126, 234, 0.3);
     --markdown-highlight-color: var(--font-color);
@@ -959,6 +963,46 @@ hulu-text-font {
 .note-title-input:focus {
     border-color: var(--theme-accent) !important;
     box-shadow: 0 0 0 2px var(--theme-accent-glow);
+}
+
+/* ==================== Diaries Page ==================== */
+
+.diaries-page-content {
+    padding: 20px;
+    min-height: 100%;
+    box-sizing: border-box;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.diaries-empty-state {
+    min-height: calc(100vh - var(--app-topbar-height) - 40px);
+}
+
+.diaries-list {
+    padding-bottom: 100px;
+}
+
+.diary-entry {
+    display: flex;
+    flex-direction: column;
+    gap: var(--diary-entry-gap);
+    padding: var(--diary-entry-padding-top) 0 var(--diary-entry-padding-bottom);
+    border-bottom: 1px solid var(--diary-entry-divider);
+}
+
+.diary-entry-title {
+    padding-left: var(--note-title-align-left);
+}
+
+.diary-entry-title .note-title,
+.diary-entry-title .note-title-input {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.diary-entry-body {
+    padding-left: 12px;
 }
 
 /* ==================== All Notes Page ==================== */

--- a/src/cljs/hulunote/diaries.cljs
+++ b/src/cljs/hulunote/diaries.cljs
@@ -1,17 +1,9 @@
 (ns hulunote.diaries
-  (:require [datascript.core :as d]
-            [rum.core :as rum]
-            [hulunote.util :as u]
+  (:require [rum.core :as rum]
             [hulunote.render :as render]
             [hulunote.db :as db]
-            [hulunote.components :as comps]
             [hulunote.sidebar :as sidebar]
-            [hulunote.router :as router]
-            [re-frame.core :as re-frame]))
-
-;; State for editing note title
-(defonce editing-note-id (atom nil))
-(defonce editing-note-title (atom ""))
+            [hulunote.router :as router]))
 
 ;; State to track if we've initialized the daily note
 (defonce daily-note-initialized? (atom #{}))
@@ -22,63 +14,12 @@
   (let [{:keys [params]} (db/get-route db)]
     (:database params)))
 
-(defn start-editing-title!
-  "Start editing a note title"
-  [note-id title]
-  (reset! editing-note-id note-id)
-  (reset! editing-note-title (or title "")))
-
-(defn cancel-editing-title!
-  "Cancel editing title"
-  []
-  (reset! editing-note-id nil)
-  (reset! editing-note-title ""))
-
-(defn save-note-title!
-  "Save the edited note title"
-  [note-id database-name]
-  (let [new-title @editing-note-title]
-    (when (not (empty? new-title))
-      ;; Update local datascript
-      (d/transact! db/dsdb
-        [[:db/add [:hulunote-notes/id note-id] :hulunote-notes/title new-title]])
-      ;; Sync to backend
-      (re-frame/dispatch-sync
-        [:update-note
-         {:note-id note-id
-          :title new-title}]))
-    ;; Clear editing state
-    (cancel-editing-title!)))
-
-(defn handle-title-key-down
-  "Handle keyboard events for title editing"
-  [e note-id database-name]
-  (let [key-code (.-keyCode e)]
-    (cond
-      ;; Enter key - save
-      (= key-code 13)
-      (do
-        (.preventDefault e)
-        (save-note-title! note-id database-name))
-      ;; Escape key - cancel
-      (= key-code 27)
-      (cancel-editing-title!))))
-
-(rum/defc note-title-editor < rum/reactive
-  "Editable note title component"
+(rum/defc note-title-link
+  "Read-only note title that opens the single note page"
   [note-id note-title database-name]
-  (let [is-editing (= note-id (rum/react editing-note-id))]
-    (if is-editing
-      [:input.note-title-input
-       {:type "text"
-        :auto-focus true
-        :value (rum/react editing-note-title)
-        :on-change #(reset! editing-note-title (.. % -target -value))
-        :on-key-down #(handle-title-key-down % note-id database-name)
-        :on-blur #(save-note-title! note-id database-name)}]
-      [:div.note-title
-       {:on-click #(start-editing-title! note-id note-title)}
-       note-title])))
+  [:div.note-title
+   {:on-click #(router/go-to-note! database-name note-id)}
+   note-title])
 
 ;; Lifecycle mixin to initialize daily note when component mounts
 (def daily-note-init-mixin
@@ -109,16 +50,15 @@
       ;; Main content area
       [:div.main-content-area
        {:class (str (when sidebar-collapsed? "sidebar-collapsed")
-                    (when right-sidebar-open? " right-sidebar-open"))}
-       [:div.flex.flex-column.overflow-scroll-new
-        {:style {:padding "20px"
-                 :max-width "900px"
-                 :margin "0 auto"}}
+                    (when right-sidebar-open? " right-sidebar-open"))
+        :style {:overflow-y "auto"
+                :height "calc(100vh - var(--app-topbar-height))"
+                :min-height 0}}
+       [:div.diaries-page-content.flex.flex-column
 
         (if (empty? daily-list)
           ;; Empty state - show message and create first note button
-          [:div.flex.flex-column.items-center.justify-center
-           {:style {:height "80vh"}}
+          [:div.diaries-empty-state.flex.flex-column.items-center.justify-center
            [:div {:style {:font-size "24px" :margin-bottom "20px"}}
             "No notes yet"]
            [:div {:style {:color "rgba(255,255,255,0.6)" :margin-bottom "30px"}}
@@ -141,21 +81,14 @@
             (str "Create Today's Note (" (sidebar/get-today-title) ")")]]
 
           ;; Show existing notes
-          (for [item daily-list]
-            (let [[note-title note-id root-nav-id] item]
-              [:div {:key note-id
-                     :style {:margin-bottom "40px"}}
-               ;; Editable note title
-               [:div.note-title-wrapper
-                (note-title-editor note-id note-title database-name)]
+          [:div.diaries-list
+           (for [item daily-list]
+             (let [[note-title note-id root-nav-id] item]
+               [:section.diary-entry {:key note-id}
+                ;; Clickable note title
+                [:div.diary-entry-title
+                 (note-title-link note-id note-title database-name)]
 
-               ;; Nav outline
-               [:div {:style {:padding-left "12px"}}
-                (render/render-navs db root-nav-id note-id database-name)]
-
-               ;; Separator
-               [:div {:style {:padding "35px 0"}}
-                [:div {:style {:background "rgba(151, 151, 151, 0.25)"
-                               :height "1px" :width "100%"}}]]])))
-
-        [:div {:style {:height "100px"}}]]]]]))
+                ;; Nav outline
+                [:div.diary-entry-body
+                 (render/render-navs db root-nav-id note-id database-name)]]))])]]]]))


### PR DESCRIPTION
## Summary
- 修正 Diaries 页面滚动归属，避免鼠标位于左侧边栏时带动日记内容滚动
- 重构 Diaries 单篇日记 section 结构，统一标题、正文和分隔线的垂直节奏
- 将 Diaries 标题从可编辑改为点击进入详情页

## Why
- Diaries 页面此前滚动落在页面级容器上，导致左侧边栏 hover + 滚轮时也会触发日记内容滚动
- 单篇日记的上下间距由多层 margin/padding 叠加控制，视觉节奏不稳定且难以继续调整
- 每日笔记标题在 Diaries 中更适合作为导航入口，而不是直接在列表页编辑

## Changes
- 为 Diaries 主内容区建立固定高度 + 内部滚动的结构
- 新增 Diaries 专用 section 样式与 spacing token
- 将单篇日记重构为 `diary-entry` / `diary-entry-title` / `diary-entry-body` 结构
- 将标题组件改为只读跳转入口，移除 Diaries 页不再需要的标题编辑逻辑

## Verification
- `npx shadow-cljs watch hulunote` 编译通过
- 在 Diaries 页面验证左侧边栏 hover + 滚轮时不再带动主内容滚动
- 在 Diaries 页面验证主内容左右空白区域也可正常滚动
- 在 Diaries 页面验证标题点击进入单笔记详情页，不再出现标题编辑框